### PR TITLE
Handle disconnects

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ moov-io/iso8583-connection is a package helping with sending, receiving and matc
 
 ## Project status
 
-ISO 8583 Connection package is in beta. Please star the project if you are interested in its progress. Please let us know if you encounter any bugs/unclear documentation or have feature suggestions by opening up an issue or pull request. Thanks!
+ISO 8583 Connection package is used in production environments. Please star the project if you are interested in its progress. Please let us know if you encounter any bugs/unclear documentation or have feature suggestions by opening up an [issue](https://github.com/moov-io/iso8583-connection/issues/new) or pull request. Thanks!
 
 ## Configuration
 
@@ -26,8 +26,9 @@ Following options are supported:
 * IdleTime - sets the period of inactivity (no messages sent) after which a ping message will be sent to the server
 * PingHandler - called when no message was sent during idle time. It should be safe for concurrent use.
 * InboundMessageHandler - called when a message from the server is received or no matching request for the message was found. InboundMessageHandler must be safe to be called concurrenty.
+* ConnectionClosedHandler - is called when connection is closed by server or there were errors during network read/write that led to connection closure
 
-If you want to override default options, you can do this when creating instance of a client:
+If you want to override default options, you can do this when creating instance of a client or setting it separately using `SetOptions(options...)` method.
 
 ```go
 pingHandler := func(c *connection.Connection) {
@@ -83,12 +84,13 @@ c, err := connection.New("127.0.0.1:443", testSpec, readMessageLength, writeMess
 ## Usage
 
 ```go
-// see configuration options for more details about different handlers
+// see configuration options for more details
 c := connection.New("127.0.0.1:9999", brandSpec, readMessageLength, writeMessageLength,
 	connection.SendTimeout(100*time.Millisecond),
 	connection.IdleTime(50*time.Millisecond),
 	connection.PingHandler(pingHandler),
 	connection.UnmatchedMessageHandler(unmatchedMessageHandler),
+	connection.ConnectionClosedHandler(connectionClosedHandler),
 )
 err := c.Connect()
 if err != nil {

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ moov-io/iso8583-connection is a package helping with sending, receiving and matc
 
 ## Project status
 
-ISO 8583 Connection package is used in production environments. Please star the project if you are interested in its progress. Please let us know if you encounter any bugs/unclear documentation or have feature suggestions by opening up an [issue](https://github.com/moov-io/iso8583-connection/issues/new) or pull request. Thanks!
+ISO 8583 Connection package is used in production environments. Please star the project if you are interested in its progress. Please let us know if you encounter any bugs/unclear documentation or have feature suggestions by [opening up an issue](https://github.com/moov-io/iso8583-connection/issues/new) or pull request. Thanks!
 
 ## Configuration
 

--- a/connection.go
+++ b/connection.go
@@ -175,8 +175,12 @@ func (c *Connection) handleConnectionError(err error) {
 		done <- true
 	}()
 
-	// close everything
+	// close everything else we close normally
 	c.close()
+
+	if c.Opts.ClosedHandler != nil {
+		c.Opts.ClosedHandler(c)
+	}
 }
 
 func (c *Connection) close() error {

--- a/connection.go
+++ b/connection.go
@@ -178,8 +178,8 @@ func (c *Connection) handleConnectionError(err error) {
 	// close everything else we close normally
 	c.close()
 
-	if c.Opts.ClosedHandler != nil {
-		c.Opts.ClosedHandler(c)
+	if c.Opts.ConnectionClosedHandler != nil {
+		c.Opts.ConnectionClosedHandler(c)
 	}
 }
 

--- a/connection.go
+++ b/connection.go
@@ -181,7 +181,7 @@ func (c *Connection) handleConnectionError(err error) {
 	c.close()
 
 	if c.Opts.ConnectionClosedHandler != nil {
-		c.Opts.ConnectionClosedHandler(c)
+		go c.Opts.ConnectionClosedHandler(c)
 	}
 }
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -484,7 +484,7 @@ func TestClient_Send(t *testing.T) {
 		closedHandler := func(c *connection.Connection) {
 			isClosedHandlerCalled = true
 		}
-		c.SetOptions(connection.ClosedHandler(closedHandler))
+		c.SetOptions(connection.ConnectionClosedHandler(closedHandler))
 
 		err = c.Connect()
 		require.NoError(t, err)

--- a/connection_test.go
+++ b/connection_test.go
@@ -17,9 +17,9 @@ import (
 )
 
 type baseFields struct {
-	MTI                  *field.String `index:"0"`
-	PrimaryAccountNumber *field.String `index:"2"`
-	STAN                 *field.String `index:"11"`
+	MTI          *field.String `index:"0"`
+	TestCaseCode *field.String `index:"2"`
+	STAN         *field.String `index:"11"`
 }
 
 var stan int
@@ -109,9 +109,9 @@ func TestClient_Send(t *testing.T) {
 		// network management message
 		message := iso8583.NewMessage(testSpec)
 		err = message.Marshal(baseFields{
-			MTI:                  field.NewStringValue("0800"),
-			PrimaryAccountNumber: field.NewStringValue(CardForDelayedResponse),
-			STAN:                 field.NewStringValue(getSTAN()),
+			MTI:          field.NewStringValue("0800"),
+			TestCaseCode: field.NewStringValue(TestCaseDelayedResponse),
+			STAN:         field.NewStringValue(getSTAN()),
 		})
 		require.NoError(t, err)
 
@@ -137,9 +137,9 @@ func TestClient_Send(t *testing.T) {
 		// network management message
 		message := iso8583.NewMessage(testSpec)
 		err = message.Marshal(baseFields{
-			MTI:                  field.NewStringValue("0800"),
-			PrimaryAccountNumber: field.NewStringValue(CardForDelayedResponse),
-			STAN:                 field.NewStringValue(getSTAN()),
+			MTI:          field.NewStringValue("0800"),
+			TestCaseCode: field.NewStringValue(TestCaseDelayedResponse),
+			STAN:         field.NewStringValue(getSTAN()),
 		})
 		require.NoError(t, err)
 
@@ -171,9 +171,9 @@ func TestClient_Send(t *testing.T) {
 		// network management message to test timeout
 		message = iso8583.NewMessage(testSpec)
 		err = message.Marshal(baseFields{
-			MTI:                  field.NewStringValue("0800"),
-			PrimaryAccountNumber: field.NewStringValue(CardForDelayedResponse),
-			STAN:                 field.NewStringValue(getSTAN()),
+			MTI:          field.NewStringValue("0800"),
+			TestCaseCode: field.NewStringValue(TestCaseDelayedResponse),
+			STAN:         field.NewStringValue(getSTAN()),
 		})
 		require.NoError(t, err)
 
@@ -219,9 +219,9 @@ func TestClient_Send(t *testing.T) {
 				// network management message
 				message := iso8583.NewMessage(testSpec)
 				err := message.Marshal(baseFields{
-					MTI:                  field.NewStringValue("0800"),
-					PrimaryAccountNumber: field.NewStringValue(CardForDelayedResponse),
-					STAN:                 field.NewStringValue(getSTAN()),
+					MTI:          field.NewStringValue("0800"),
+					TestCaseCode: field.NewStringValue(TestCaseDelayedResponse),
+					STAN:         field.NewStringValue(getSTAN()),
 				})
 				require.NoError(t, err)
 
@@ -267,9 +267,9 @@ func TestClient_Send(t *testing.T) {
 
 			message := iso8583.NewMessage(testSpec)
 			err := message.Marshal(baseFields{
-				MTI:                  field.NewStringValue("0800"),
-				PrimaryAccountNumber: field.NewStringValue(CardForDelayedResponse),
-				STAN:                 field.NewStringValue(getSTAN()),
+				MTI:          field.NewStringValue("0800"),
+				TestCaseCode: field.NewStringValue(TestCaseDelayedResponse),
+				STAN:         field.NewStringValue(getSTAN()),
 			})
 			require.NoError(t, err)
 
@@ -334,9 +334,9 @@ func TestClient_Send(t *testing.T) {
 		pingHandler := func(c *connection.Connection) {
 			pingMessage := iso8583.NewMessage(testSpec)
 			err := pingMessage.Marshal(baseFields{
-				MTI:                  field.NewStringValue("0800"),
-				PrimaryAccountNumber: field.NewStringValue(CardForPingCounter),
-				STAN:                 field.NewStringValue(getSTAN()),
+				MTI:          field.NewStringValue("0800"),
+				TestCaseCode: field.NewStringValue(TestCasePingCounter),
+				STAN:         field.NewStringValue(getSTAN()),
 			})
 			require.NoError(t, err)
 
@@ -378,7 +378,7 @@ func TestClient_Send(t *testing.T) {
 
 			pan, err := message.GetString(2)
 			require.NoError(t, err)
-			require.Equal(t, CardForDelayedResponse, pan)
+			require.Equal(t, TestCaseDelayedResponse, pan)
 		}
 
 		c, err := connection.New(server.Addr, testSpec, readMessageLength, writeMessageLength,
@@ -394,9 +394,9 @@ func TestClient_Send(t *testing.T) {
 		// network management message to test timeout
 		message := iso8583.NewMessage(testSpec)
 		err = message.Marshal(baseFields{
-			MTI:                  field.NewStringValue("0800"),
-			PrimaryAccountNumber: field.NewStringValue(CardForDelayedResponse),
-			STAN:                 field.NewStringValue(getSTAN()),
+			MTI:          field.NewStringValue("0800"),
+			TestCaseCode: field.NewStringValue(TestCaseDelayedResponse),
+			STAN:         field.NewStringValue(getSTAN()),
 		})
 		require.NoError(t, err)
 
@@ -441,9 +441,9 @@ func TestClient_Send(t *testing.T) {
 		// network management message to test timeout
 		message := iso8583.NewMessage(testSpec)
 		err = message.Marshal(baseFields{
-			MTI:                  field.NewStringValue("0800"),
-			PrimaryAccountNumber: field.NewStringValue(CardForSameSTANRequest),
-			STAN:                 field.NewStringValue(originalSTAN),
+			MTI:          field.NewStringValue("0800"),
+			TestCaseCode: field.NewStringValue(TestCaseSameSTANRequest),
+			STAN:         field.NewStringValue(originalSTAN),
 		})
 		require.NoError(t, err)
 
@@ -470,6 +470,28 @@ func TestClient_Send(t *testing.T) {
 		c.Reply(msg)
 
 		require.Equal(t, closer.Used, true, "client didn't use custom connection")
+	})
+
+	t.Run("it fails? when connection was closed by server", func(t *testing.T) {
+		c, err := connection.New(server.Addr, testSpec, readMessageLength, writeMessageLength)
+		require.NoError(t, err)
+
+		err = c.Connect()
+		require.NoError(t, err)
+
+		// network management message
+		message := iso8583.NewMessage(testSpec)
+		err = message.Marshal(baseFields{
+			MTI:          field.NewStringValue("0800"),
+			TestCaseCode: field.NewStringValue(TestCaseDelayedResponse),
+			STAN:         field.NewStringValue(getSTAN()),
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, c.Close())
+
+		_, err = c.Send(message)
+		require.Equal(t, connection.ErrConnectionClosed, err)
 	})
 }
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -57,10 +57,10 @@ var testSpec *iso8583.MessageSpec = &iso8583.MessageSpec{
 			Pref:        prefix.Binary.Fixed,
 		}),
 		2: field.NewString(&field.Spec{
-			Length:      19,
-			Description: "Primary Account Number",
+			Length:      3,
+			Description: "Test Case Code",
 			Enc:         encoding.ASCII,
-			Pref:        prefix.ASCII.LL,
+			Pref:        prefix.ASCII.Fixed,
 		}),
 		7: field.NewString(&field.Spec{
 			Length:      10,
@@ -102,11 +102,11 @@ func (t *testServer) ReceivedPings() int {
 }
 
 const (
-	CardForDelayedResponse string = "4200000000000000"
-	CardForPingCounter     string = "4005550000000019"
+	TestCaseDelayedResponse string = "001"
+	TestCasePingCounter     string = "002"
 	// for sending incoming message with same STAN as
 	// received message
-	CardForSameSTANRequest string = "4012888888881881"
+	TestCaseSameSTANRequest string = "003"
 )
 
 func NewTestServer() (*testServer, error) {
@@ -139,11 +139,11 @@ func NewTestServer() (*testServer, error) {
 			}
 
 			switch code {
-			case CardForDelayedResponse:
+			case TestCaseDelayedResponse:
 				// testing value to "sleep" for a 3 seconds
 				time.Sleep(500 * time.Millisecond)
 
-			case CardForSameSTANRequest:
+			case TestCaseSameSTANRequest:
 				// here we will send message to the client with
 				// the same STAN
 				stan, _ := message.GetString(11)
@@ -159,7 +159,7 @@ func NewTestServer() (*testServer, error) {
 				// and then delay the reply
 				time.Sleep(200 * time.Millisecond)
 
-			case CardForPingCounter:
+			case TestCasePingCounter:
 				// ping request received
 				srv.Ping()
 			}

--- a/options.go
+++ b/options.go
@@ -30,6 +30,10 @@ type Options struct {
 	// * to handle network management messages (echo, heartbeat, etc.)
 	InboundMessageHandler func(c *Connection, message *iso8583.Message)
 
+	// ClosedHandler is called when connection is closed by server or there
+	// were network errors during network read/write
+	ClosedHandler func(c *Connection)
+
 	TLSConfig *tls.Config
 }
 
@@ -64,6 +68,14 @@ func SendTimeout(d time.Duration) Option {
 func PingHandler(handler func(c *Connection)) Option {
 	return func(o *Options) error {
 		o.PingHandler = handler
+		return nil
+	}
+}
+
+// ClosedHandler sets a ClosedHandler option
+func ClosedHandler(handler func(c *Connection)) Option {
+	return func(o *Options) error {
+		o.ClosedHandler = handler
 		return nil
 	}
 }

--- a/options.go
+++ b/options.go
@@ -30,9 +30,9 @@ type Options struct {
 	// * to handle network management messages (echo, heartbeat, etc.)
 	InboundMessageHandler func(c *Connection, message *iso8583.Message)
 
-	// ClosedHandler is called when connection is closed by server or there
+	// ConnectionClosedHandler is called when connection is closed by server or there
 	// were network errors during network read/write
-	ClosedHandler func(c *Connection)
+	ConnectionClosedHandler func(c *Connection)
 
 	TLSConfig *tls.Config
 }
@@ -72,10 +72,10 @@ func PingHandler(handler func(c *Connection)) Option {
 	}
 }
 
-// ClosedHandler sets a ClosedHandler option
-func ClosedHandler(handler func(c *Connection)) Option {
+// ConnectionClosedHandler sets a ConnectionClosedHandler option
+func ConnectionClosedHandler(handler func(c *Connection)) Option {
 	return func(o *Options) error {
-		o.ClosedHandler = handler
+		o.ConnectionClosedHandler = handler
 		return nil
 	}
 }


### PR DESCRIPTION
# Summary
* handle network read/write errors
* call `ConnectionClosedHandler` when the connection is closed because of network errors (server closed the connection)
* rename `PrimaryAccountNumber` in test messages into `TestCaseCode` to make it easier to test different test cases

# Details

We implemented the network error handling in the PR. The solution is pretty simple: it rejects new messages, closes pending requests (sent messages), and in the end, we call the client’s handler to notify them about the closed connection. The idea here is to make the client be responsible for handling re-connects. Such an approach has pros and cons.

**Pros:**

- we can make package code simple and rely on the infrastructure to restart and notify us about issues:
    - in the client, we can re-create a connection (throw away the old connection and create a new one), change the client's status, etc.
    - in the `ConnectionClosedHandler`, we can terminate the whole server, and the orchestrator (e.g., k8s) will restart it and notify us via PagerDuty (or something like this) if the service failed to start (because of iso8583 connection issues)
- code inside `iso8583-connection` is simpler: no code and options to re-connect, etc.
- **client knows how to sign in properly, while the connection is dumb and can’t do this (there is the solution for this described below)**

**Cons:**

- connection will reject all new messages right after the connection is closed by the server and if it’s possible to re-establish the connection, we may increase the number of processed messages
- you have to rely on infrastructure to re-start and alert about service issues (which you must have anyway :)
- it seems too brutal to terminate the whole service because of the connection issue (if there is a chance to restore the connection)

## Re-connect option

As a next change, to compensate for the drawbacks of the solution in the PR, we can implement the `re-connect` option inside the `iso8583-connection` package. It will:

- put on pause all requests while we are reconnecting
- notify the client that the connection is disconnected so it can change its status to offline and not accept any new incoming requests (add `DisconnectedHandler` option)
- try to re-connect (x times, with jitter, etc.)
- call custom logic to sign in on successful re-connect (add `ReconnectHandler` option)
- proceed with requests and pending messages

With `re-connect` options, we do not reject new messages when the connection is disconnected and when it’s possible to re-connect. If we re-connect successfully, we continue with queued messages without any drops. 

In addition, all sent (pending) messages (pending) will timeout, and the logic inside the client to handle `lateReply` will stay the same. This will make it possible to distinguish timeout errors from connection errors and send reversal messages accordingly. If re-connect fails, all requests will receive `ClosedConnectionError,` and it will be a client's responsibility to do something with it.

What's important is that the `re-connect` option will not require any changes to clients who will use `ClosedConnectionHandler` as `re-connect` will be not visible to the consumers and will require only the addition of `ReconnectHandler`