### PR TITLE
Implement Accept function to support server/listen mode

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -172,13 +172,13 @@ func (c *Connection) Accept() error {
 			if c.Opts.ConnectionAcceptHandler != nil {
 				go c.Opts.ConnectionAcceptHandler(nil, errors.New(msg))
 			}
-			fmt.Print(msg)
+			log.Print(msg)
 		case <- chErr:
 			msg := fmt.Sprintf("accepting server connection %s: %v", c.addr, err)
 			if c.Opts.ConnectionAcceptHandler != nil {
 				go c.Opts.ConnectionAcceptHandler(nil, errors.New(msg))
 			}
-			fmt.Print(msg)
+			log.Print(msg)
 		}
 	}()
 

--- a/connection.go
+++ b/connection.go
@@ -164,19 +164,19 @@ func (c *Connection) Accept() error {
 			c.conn = conn
 			c.run()
 
-			if c.Opts.ConnectionOpenedHandler != nil {
-				go c.Opts.ConnectionOpenedHandler(c, nil)
+			if c.Opts.ConnectionAcceptHandler != nil {
+				go c.Opts.ConnectionAcceptHandler(c, nil)
 			}
 		case <-time.After(c.Opts.ConnectTimeout):
 			msg := "timed out waiting for connection"
-			if c.Opts.ConnectionOpenedHandler != nil {
-				go c.Opts.ConnectionOpenedHandler(nil, errors.New(msg))
+			if c.Opts.ConnectionAcceptHandler != nil {
+				go c.Opts.ConnectionAcceptHandler(nil, errors.New(msg))
 			}
 			fmt.Print(msg)
 		case <- chErr:
 			msg := fmt.Sprintf("accepting server connection %s: %v", c.addr, err)
-			if c.Opts.ConnectionOpenedHandler != nil {
-				go c.Opts.ConnectionOpenedHandler(nil, errors.New(msg))
+			if c.Opts.ConnectionAcceptHandler != nil {
+				go c.Opts.ConnectionAcceptHandler(nil, errors.New(msg))
 			}
 			fmt.Print(msg)
 		}

--- a/connection.go
+++ b/connection.go
@@ -137,21 +137,17 @@ func (c *Connection) Connect() error {
 // Accept accepts a connection to the server using the configured address and should be used when the other party
 // is responsible for establishing the connection.
 func (c *Connection) Accept() error {
-	var conn net.Conn
-	var err error
-
 	listener, err := net.Listen("tcp", c.addr)
 	if err != nil {
 		return fmt.Errorf("creating listener %s: %w", c.addr, err)
 	}
 
-	conn, err = listener.Accept()
+	conn, err := listener.Accept()
 	if err != nil {
-		return fmt.Errorf("connecting to server %s: %w", c.addr, err)
+		return fmt.Errorf("accepting server connection %s: %w", c.addr, err)
 	}
-	
+
 	c.conn = conn
-	
 	c.run()
 
 	return nil

--- a/connection.go
+++ b/connection.go
@@ -173,14 +173,12 @@ func (c *Connection) Accept() error {
 				go c.Opts.ConnectionOpenedHandler(nil, errors.New(msg))
 			}
 			fmt.Print(msg)
-			return
 		case <- chErr:
 			msg := fmt.Sprintf("accepting server connection %s: %v", c.addr, err)
 			if c.Opts.ConnectionOpenedHandler != nil {
 				go c.Opts.ConnectionOpenedHandler(nil, errors.New(msg))
 			}
 			fmt.Print(msg)
-			return
 		}
 	}()
 

--- a/connection.go
+++ b/connection.go
@@ -134,16 +134,11 @@ func (c *Connection) Connect() error {
 	return nil
 }
 
-// Listen accepts a connection to the server using the configured address and should be used when the other party
+// Accept accepts a connection to the server using the configured address and should be used when the other party
 // is responsible for establishing the connection.
-func (c *Connection) Listen() error {
+func (c *Connection) Accept() error {
 	var conn net.Conn
 	var err error
-
-	if c.conn != nil {
-		c.run()
-		return nil
-	}
 
 	listener, err := net.Listen("tcp", c.addr)
 	if err != nil {

--- a/connection.go
+++ b/connection.go
@@ -106,7 +106,8 @@ func (c *Connection) SetOptions(options ...Option) error {
 	return nil
 }
 
-// Connect establishes the connection to the server using configured Addr
+// Connect establishes a connection to the server using configured address and should be used when the implementing
+// party is responsible for establishing the connection.
 func (c *Connection) Connect() error {
 	var conn net.Conn
 	var err error
@@ -128,6 +129,34 @@ func (c *Connection) Connect() error {
 
 	c.conn = conn
 
+	c.run()
+
+	return nil
+}
+
+// Listen accepts a connection to the server using the configured address and should be used when the other party
+// is responsible for establishing the connection.
+func (c *Connection) Listen() error {
+	var conn net.Conn
+	var err error
+
+	if c.conn != nil {
+		c.run()
+		return nil
+	}
+
+	listener, err := net.Listen("tcp", c.addr)
+	if err != nil {
+		return fmt.Errorf("creating listener %s: %w", c.addr, err)
+	}
+
+	conn, err = listener.Accept()
+	if err != nil {
+		return fmt.Errorf("connecting to server %s: %w", c.addr, err)
+	}
+	
+	c.conn = conn
+	
 	c.run()
 
 	return nil

--- a/connection_test.go
+++ b/connection_test.go
@@ -634,7 +634,7 @@ func TestClientAccept(t *testing.T) {
 	addr := "127.0.0.1:8888"
 
 	opts := []connection.Option{
-		connection.ConnectionOpenedHandler(func(c *connection.Connection, err error) {
+		connection.ConnectionAcceptHandler(func(c *connection.Connection, err error) {
 			m.Lock()
 			callbackInvoked = true
 			require.NoError(t, err)

--- a/options.go
+++ b/options.go
@@ -14,7 +14,7 @@ type Options struct {
 	// SendTimeout sets the timeout for a Send operation
 	SendTimeout time.Duration
 
-	// ConnectTimeout sets the timeout for a Accepting a connection when running in server mode
+	// ConnectTimeout sets the timeout for a Accepting a connection when running in listen/server mode
 	ConnectTimeout time.Duration
 
 	// IdleTime is the period at which the client will be sending ping
@@ -37,9 +37,9 @@ type Options struct {
 	// were network errors during network read/write
 	ConnectionClosedHandler func(c *Connection)
 
-	// ConnectionOpenedHandler is called when a connection is established. Used when client
-	// is operating in listen/server mode.
-	ConnectionOpenedHandler func(c *Connection, err error)
+	// ConnectionAcceptHandler is called when a connection is accepted or an error or timeout
+	// occurs as part of accepting a connection. Used when client is operating in listen/server mode.
+	ConnectionAcceptHandler func(c *Connection, err error)
 
 	TLSConfig *tls.Config
 }
@@ -96,10 +96,10 @@ func ConnectionClosedHandler(handler func(c *Connection)) Option {
 	}
 }
 
-// ConnectionOpeneddHandler sets a ConnectionOpenedHandler option
-func ConnectionOpenedHandler(handler func(c *Connection, err error)) Option {
+// ConnectionAcceptHandler sets a ConnectionAcceptHandler option
+func ConnectionAcceptHandler(handler func(c *Connection, err error)) Option {
 	return func(o *Options) error {
-		o.ConnectionOpenedHandler = handler
+		o.ConnectionAcceptHandler = handler
 		return nil
 	}
 }

--- a/options.go
+++ b/options.go
@@ -34,6 +34,10 @@ type Options struct {
 	// were network errors during network read/write
 	ConnectionClosedHandler func(c *Connection)
 
+	// ConnectionOpenedHandler is called when a connection is established. Used when client
+	// is operating in listen/server mode.
+	ConnectionOpenedHandler func(c *Connection, err error)
+
 	TLSConfig *tls.Config
 }
 
@@ -76,6 +80,14 @@ func PingHandler(handler func(c *Connection)) Option {
 func ConnectionClosedHandler(handler func(c *Connection)) Option {
 	return func(o *Options) error {
 		o.ConnectionClosedHandler = handler
+		return nil
+	}
+}
+
+// ConnectionOpeneddHandler sets a ConnectionOpenedHandler option
+func ConnectionOpenedHandler(handler func(c *Connection, err error)) Option {
+	return func(o *Options) error {
+		o.ConnectionOpenedHandler = handler
 		return nil
 	}
 }

--- a/options.go
+++ b/options.go
@@ -14,6 +14,9 @@ type Options struct {
 	// SendTimeout sets the timeout for a Send operation
 	SendTimeout time.Duration
 
+	// ConnectTimeout sets the timeout for a Accepting a connection when running in server mode
+	ConnectTimeout time.Duration
+
 	// IdleTime is the period at which the client will be sending ping
 	// message to the server
 	IdleTime time.Duration
@@ -46,6 +49,7 @@ type Option func(*Options) error
 func GetDefaultOptions() Options {
 	return Options{
 		SendTimeout: 30 * time.Second,
+		ConnectTimeout: 30 * time.Second,
 		IdleTime:    5 * time.Second,
 		PingHandler: nil,
 		TLSConfig:   nil,
@@ -64,6 +68,14 @@ func IdleTime(d time.Duration) Option {
 func SendTimeout(d time.Duration) Option {
 	return func(o *Options) error {
 		o.SendTimeout = d
+		return nil
+	}
+}
+
+// ConnectTimeout sets an ConnectTimeout option
+func ConnectTimeout(d time.Duration) Option {
+	return func(o *Options) error {
+		o.ConnectTimeout = d
 		return nil
 	}
 }


### PR DESCRIPTION
The underlying `net.Conn` object that this project wraps supports `Dial`, `Listen` and `Accept` functions. Those functions allow a connection to either initiate a connection or accept an incoming connection. 

This project already supports initiating (`Connect`) via `Dial`, this adds `Accept` functionality through the underlying `Listen` and `Accept` capabilities.