### PR TITLE
Add connection pool

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.19
+        go-version: ^1.19.1
       id: go
 
     - name: Check out code into the Go module directory

--- a/README.md
+++ b/README.md
@@ -123,6 +123,93 @@ if mti != "0810" {
 }
 ```
 
+## Connection `Pool`
+
+Sometimes you want to establish connections to multiple servers and re-create
+them when such connections are closed due to a network errors. Connection `Pool`
+is really helpful for such use cases.
+
+To use `Pool` first, you need to create factory function that knows how to create
+connections and list of adresses you want to establish connection with.
+
+```go
+// Factory method that will build connection
+factory := func(addr string) (*connection.Connection, error) {
+	c, err := connection.New(
+		addr,
+		testSpec,
+		readMessageLength,
+		writeMessageLength,
+		// set shot connect timeout so we can test re-connects
+		connection.ConnectTimeout(500*time.Millisecond),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("building iso8583 connection: %w", err)
+	}
+
+	return c, nil
+}
+```
+
+if there is a need to apply address specific configurations like TLS, you can create a map or function that will return all needed options for the address:
+
+```go
+func getAddrOpts(addr string) []Option {
+	switch addr {
+	case "127.0.0.1":
+		return []Option{
+			connection.ClientCert(certA, keyA),
+		}
+	case "127.0.0.2":
+		return []Option{
+			connection.ClientCert(certB, keyB),
+		}
+	}
+}
+
+factory := func(addr string) (*connection.Connection, error) {
+	c, err := connection.New(
+		addr,
+		testSpec,
+		readMessageLength,
+		writeMessageLength,
+		connection.ConnectTimeout(500*time.Millisecond),
+		getAddrOpts(addr)...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("building iso8583 connection: %w", err)
+	}
+
+	return c, nil
+}
+```
+
+Now you can establish all connections:
+
+```go
+err = pool.Connect()
+// handle error
+```
+
+When pool is connected, you can get connection from the pool to send message to:
+
+```go
+conn, err := pool.Get()
+// handle err
+
+// create iso8583 message
+msg := iso8583.NewMessage(yourSpec)
+// ...
+
+reply, err := conn.Send(msg)
+// handle error
+```
+
+Because `Connection` is safe to be used concurrently, you don't return
+connection back to the pool. But don't close the connection directly as the
+pool will remove it from the pool of connections only when connection is closed
+by the server. It does it using `ConnectionClosedHandler`.
+
 ## Benchmark
 
 To benchmark the connection, run:

--- a/connection.go
+++ b/connection.go
@@ -217,8 +217,10 @@ func (c *Connection) handleConnectionError(err error) {
 	// close everything else we close normally
 	c.close()
 
-	if c.Opts.ConnectionClosedHandler != nil {
-		go c.Opts.ConnectionClosedHandler(c)
+	if c.Opts.ConnectionClosedHandler != nil && len(c.Opts.ConnectionClosedHandler) > 0 {
+		for _, handler := range c.Opts.ConnectionClosedHandler {
+			go handler(c)
+		}
 	}
 }
 

--- a/connection.go
+++ b/connection.go
@@ -153,6 +153,17 @@ func (c *Connection) Connect() error {
 
 	c.run()
 
+	if c.Opts.OnConnect != nil {
+		if err := c.Opts.OnConnect(c); err != nil {
+			// close connection if OnConnect failed
+			// but ignore the potential error from Close()
+			// as it's a rare case
+			_ = c.Close()
+
+			return fmt.Errorf("on connect callback %s: %w", c.Addr, err)
+		}
+	}
+
 	if c.Opts.ConnectionEstablishedHandler != nil {
 		go c.Opts.ConnectionEstablishedHandler(c)
 	}

--- a/connection.go
+++ b/connection.go
@@ -217,8 +217,8 @@ func (c *Connection) handleConnectionError(err error) {
 	// close everything else we close normally
 	c.close()
 
-	if c.Opts.ConnectionClosedHandler != nil && len(c.Opts.ConnectionClosedHandler) > 0 {
-		for _, handler := range c.Opts.ConnectionClosedHandler {
+	if c.Opts.ConnectionClosedHandlers != nil && len(c.Opts.ConnectionClosedHandlers) > 0 {
+		for _, handler := range c.Opts.ConnectionClosedHandlers {
 			go handler(c)
 		}
 	}

--- a/connection.go
+++ b/connection.go
@@ -46,7 +46,7 @@ func (e *ErrUnpack) Unwrap() error {
 // Connection represents an ISO 8583 Connection. Connection may be used
 // by multiple goroutines simultaneously.
 type Connection struct {
-	Addr           string
+	addr           string
 	Opts           Options
 	conn           io.ReadWriteCloser
 	requestsCh     chan request
@@ -90,7 +90,7 @@ func New(addr string, spec *iso8583.MessageSpec, mlReader MessageLengthReader, m
 	}
 
 	return &Connection{
-		Addr:               addr,
+		addr:               addr,
 		Opts:               opts,
 		requestsCh:         make(chan request),
 		readResponseCh:     make(chan []byte),
@@ -140,13 +140,13 @@ func (c *Connection) Connect() error {
 	d := &net.Dialer{Timeout: c.Opts.ConnectTimeout}
 
 	if c.Opts.TLSConfig != nil {
-		conn, err = tls.DialWithDialer(d, "tcp", c.Addr, c.Opts.TLSConfig)
+		conn, err = tls.DialWithDialer(d, "tcp", c.addr, c.Opts.TLSConfig)
 	} else {
-		conn, err = d.Dial("tcp", c.Addr)
+		conn, err = d.Dial("tcp", c.addr)
 	}
 
 	if err != nil {
-		return fmt.Errorf("connecting to server %s: %w", c.Addr, err)
+		return fmt.Errorf("connecting to server %s: %w", c.addr, err)
 	}
 
 	c.conn = conn
@@ -160,7 +160,7 @@ func (c *Connection) Connect() error {
 			// as it's a rare case
 			_ = c.Close()
 
-			return fmt.Errorf("on connect callback %s: %w", c.Addr, err)
+			return fmt.Errorf("on connect callback %s: %w", c.addr, err)
 		}
 	}
 
@@ -619,4 +619,9 @@ func (c *Connection) Set(key, value string) {
 	defer c.mutex.Unlock()
 
 	c.kv[key] = value
+}
+
+// Addr returns the remote address of the connection
+func (c *Connection) Addr() string {
+	return c.addr
 }

--- a/connection_test.go
+++ b/connection_test.go
@@ -786,6 +786,10 @@ func TestClient_Options(t *testing.T) {
 		defer c.Close()
 		require.Equal(t, int32(0), atomic.LoadInt32(&callsCounter))
 
+		// let's wait for server and client to connect
+		// before we close the server
+		time.Sleep(100 * time.Millisecond)
+
 		// when we close server
 		server.Close()
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -721,7 +721,7 @@ func TestClient_Send(t *testing.T) {
 		}
 
 		c, err := connection.New(server.Addr, testSpec, readMessageLength, writeMessageLength,
-			connection.ReadTimeout(50*time.Millisecond),
+			connection.ReadTimeout(100*time.Millisecond),
 			connection.ReadTimeoutHandler(readTimeoutHandler),
 		)
 		require.NoError(t, err)

--- a/connection_test.go
+++ b/connection_test.go
@@ -889,21 +889,14 @@ func TestClient_Options(t *testing.T) {
 }
 
 func TestConnection(t *testing.T) {
-	t.Run("Get", func(t *testing.T) {
+	t.Run("Status", func(t *testing.T) {
 		c, err := connection.New("1.1.1.1", nil, nil, nil)
 
 		require.NoError(t, err)
-		require.Empty(t, c.Get("status"))
-	})
+		require.Empty(t, c.Status())
 
-	// test Set for connection
-	t.Run("Set", func(t *testing.T) {
-		c, err := connection.New("1.1.1.1", nil, nil, nil)
-
-		require.NoError(t, err)
-
-		c.Set("status", "connected")
-		require.Equal(t, "connected", c.Get("status"))
+		c.SetStatus(connection.StatusOnline)
+		require.Equal(t, connection.StatusOnline, c.Status())
 	})
 }
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -118,7 +118,7 @@ const (
 	TestCaseRespondWithExtraField string = "005"
 )
 
-func NewTestServer() (*testServer, error) {
+func NewTestServerWithAddr(addr string) (*testServer, error) {
 	var srv *testServer
 
 	// define logic for our test server
@@ -190,7 +190,7 @@ func NewTestServer() (*testServer, error) {
 
 	server := server.New(testSpec, readMessageLength, writeMessageLength, connection.InboundMessageHandler(testServerLogic))
 	// start on random port
-	err := server.Start("127.0.0.1:")
+	err := server.Start(addr)
 	if err != nil {
 		return nil, err
 	}
@@ -201,6 +201,10 @@ func NewTestServer() (*testServer, error) {
 	}
 
 	return srv, nil
+}
+
+func NewTestServer() (*testServer, error) {
+	return NewTestServerWithAddr("127.0.0.1:")
 }
 
 func (t *testServer) Close() {

--- a/helper_test.go
+++ b/helper_test.go
@@ -87,7 +87,7 @@ var testSpec *iso8583.MessageSpec = &iso8583.MessageSpec{
 type testServer struct {
 	Addr string
 
-	server *server.Server
+	Server *server.Server
 
 	// to protect following
 	mutex         sync.Mutex
@@ -196,7 +196,7 @@ func NewTestServer() (*testServer, error) {
 	}
 
 	srv = &testServer{
-		server: server,
+		Server: server,
 		Addr:   server.Addr,
 	}
 
@@ -204,5 +204,5 @@ func NewTestServer() (*testServer, error) {
 }
 
 func (t *testServer) Close() {
-	t.server.Close()
+	t.Server.Close()
 }

--- a/options.go
+++ b/options.go
@@ -43,7 +43,7 @@ type Options struct {
 
 	// ConnectionClosedHandler is called when connection is closed by server or there
 	// were network errors during network read/write
-	ConnectionClosedHandler func(c *Connection)
+	ConnectionClosedHandler []func(c *Connection)
 
 	// ConnectionEstablishedHandler is called when connection is
 	// established with the server
@@ -120,7 +120,7 @@ func PingHandler(handler func(c *Connection)) Option {
 // ConnectionClosedHandler sets a ConnectionClosedHandler option
 func ConnectionClosedHandler(handler func(c *Connection)) Option {
 	return func(o *Options) error {
-		o.ConnectionClosedHandler = handler
+		o.ConnectionClosedHandler = append(o.ConnectionClosedHandler, handler)
 		return nil
 	}
 }

--- a/options.go
+++ b/options.go
@@ -54,6 +54,9 @@ type Options struct {
 	// ErrorHandler is called in a goroutine with the errors that can't be
 	// returned to the caller
 	ErrorHandler func(err error)
+
+	// OnConnect is called synchronously when a connection is established
+	OnConnect func(c *Connection) error
 }
 
 type Option func(*Options) error
@@ -146,6 +149,15 @@ func InboundMessageHandler(handler func(c *Connection, message *iso8583.Message)
 func ErrorHandler(h func(err error)) Option {
 	return func(opts *Options) error {
 		opts.ErrorHandler = h
+		return nil
+	}
+}
+
+// OnConnect sets a callback that will be synchronously  called when connection is established.
+// If it returns error, then connections will be closed and re-connect will be attempted
+func OnConnect(h func(c *Connection) error) Option {
+	return func(opts *Options) error {
+		opts.OnConnect = h
 		return nil
 	}
 }

--- a/options.go
+++ b/options.go
@@ -41,9 +41,9 @@ type Options struct {
 	// * to handle network management messages (echo, heartbeat, etc.)
 	InboundMessageHandler func(c *Connection, message *iso8583.Message)
 
-	// ConnectionClosedHandler is called when connection is closed by server or there
+	// ConnectionClosedHandlers is called when connection is closed by server or there
 	// were network errors during network read/write
-	ConnectionClosedHandler []func(c *Connection)
+	ConnectionClosedHandlers []func(c *Connection)
 
 	// ConnectionEstablishedHandler is called when connection is
 	// established with the server
@@ -120,7 +120,7 @@ func PingHandler(handler func(c *Connection)) Option {
 // ConnectionClosedHandler sets a ConnectionClosedHandler option
 func ConnectionClosedHandler(handler func(c *Connection)) Option {
 	return func(o *Options) error {
-		o.ConnectionClosedHandler = append(o.ConnectionClosedHandler, handler)
+		o.ConnectionClosedHandlers = append(o.ConnectionClosedHandlers, handler)
 		return nil
 	}
 }

--- a/pool.go
+++ b/pool.go
@@ -80,25 +80,6 @@ func (p *Pool) Connect() error {
 			continue
 		}
 
-		if p.Opts.OnConnect != nil {
-			err := p.Opts.OnConnect(conn)
-			if err != nil {
-				p.handleError(fmt.Errorf("on connect handler for %s: %w", conn.Addr, err))
-
-				// becase connection was established, we should close it
-				// theoretically, if it fails to close, we may leak connection
-				// but it's rare case and we can't do anything about it
-				err = conn.Close()
-				if err != nil {
-					p.handleError(fmt.Errorf("closing connection after failed on connect handler to %s: %w", conn.Addr, err))
-				}
-
-				p.wg.Add(1)
-				go p.recreateConnection(conn)
-				continue
-			}
-		}
-
 		p.connections = append(p.connections, conn)
 	}
 
@@ -198,17 +179,7 @@ func (p *Pool) recreateConnection(closedConn *Connection) {
 		err = conn.Connect()
 
 		if err == nil {
-			if p.Opts.OnConnect == nil {
-				break
-			}
-
-			err = p.Opts.OnConnect(conn)
-			if err == nil {
-				break
-			}
-
-			// ignore error here is we can't do anything about it
-			_ = conn.Close()
+			break
 		}
 
 		p.handleError(fmt.Errorf("failed to reconnect to %s: %w", conn.Addr, err))

--- a/pool.go
+++ b/pool.go
@@ -261,3 +261,24 @@ func (p *Pool) Close() error {
 func (p *Pool) Done() <-chan struct{} {
 	return p.done
 }
+
+// IsDegraded returns true if pool is not full
+func (p *Pool) IsDegraded() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// filtered connections
+	var conns []*Connection
+
+	if p.Opts.ConnectionsFilter != nil {
+		for _, conn := range p.connections {
+			if p.Opts.ConnectionsFilter(conn) {
+				conns = append(conns, conn)
+			}
+		}
+	} else {
+		conns = p.connections
+	}
+
+	return len(p.Addrs) != len(conns)
+}

--- a/pool.go
+++ b/pool.go
@@ -126,7 +126,7 @@ func (p *Pool) Get() (*Connection, error) {
 		conns = p.connections
 	}
 
-	if conns == nil || len(conns) == 0 {
+	if len(conns) == 0 {
 		return nil, errors.New("no (filtered) connections in the pool")
 	}
 

--- a/pool.go
+++ b/pool.go
@@ -3,7 +3,6 @@ package connection
 import (
 	"errors"
 	"fmt"
-	"log"
 	"sync"
 	"time"
 )
@@ -13,34 +12,55 @@ type ConnectionFactoryFunc func(addr string) (*Connection, error)
 type Pool struct {
 	Factory ConnectionFactoryFunc
 	Addrs   []string
+	Opts    PoolOptions
 
 	mu          sync.Mutex
 	connections []*Connection
 	connIndex   int
 
 	done chan struct{}
+
+	// WaitGroup to wait for all reconnect goroutines return
+	wg sync.WaitGroup
+
+	isClosed bool
 }
 
-// Pool - provides connection to the clients. It checks the health of the
-// connection and if connection is not healthy it removes it from the pool and
-// in the background will try to create new connection so pool will be full.
-// Pool needs a list of IP addresses (connection configs) to create connections for.
-
-func NewPool(factory ConnectionFactoryFunc, addrs []string) *Pool {
-	// fill the connection pool
-	// check health of the connections in the goroutine
+// Pool - provides connections to the clients. It removes the connection from
+// the pool if it was closed and in the background tries to create and etablish
+// new connection so the pool will be full.
+func NewPool(factory ConnectionFactoryFunc, addrs []string, options ...PoolOption) (*Pool, error) {
+	opts := GetDefaultPoolOptions()
+	for _, opt := range options {
+		if err := opt(&opts); err != nil {
+			return nil, fmt.Errorf("setting pool option: %v %w", opt, err)
+		}
+	}
 
 	return &Pool{
-		Factory: factory,
-		Addrs:   addrs,
-		done:    make(chan struct{}),
+		Factory:     factory,
+		Opts:        opts,
+		Addrs:       addrs,
+		done:        make(chan struct{}),
+		connections: make([]*Connection, 0),
+	}, nil
+}
+
+func (p *Pool) handleError(err error) {
+	if p.Opts.ErrorHandler == nil {
+		return
 	}
+
+	go p.Opts.ErrorHandler(err)
 }
 
 // Connect creates poll of connections by calling Factory method and connect them all
 func (p *Pool) Connect() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	if p.isClosed {
+		return errors.New("pool is closed")
+	}
 
 	// build connections
 	for _, addr := range p.Addrs {
@@ -54,16 +74,23 @@ func (p *Pool) Connect() error {
 
 		err = conn.Connect()
 		if err != nil {
-			return fmt.Errorf("connecting to %s: %w", conn.Addr, err)
+			p.handleError(fmt.Errorf("connecting to %s: %w", conn.Addr, err))
+			p.wg.Add(1)
+			go p.recreateConnection(conn)
+			continue
 		}
 
 		p.connections = append(p.connections, conn)
 	}
 
+	if len(p.connections) < p.Opts.MinConnections {
+		return fmt.Errorf("minimum %d connections is required, established: %d", p.Opts.MinConnections, len(p.connections))
+	}
+
 	return nil
 }
 
-// Get returns connection from the pool
+// Connections returns copy of all connections from the pool
 func (p *Pool) Connections() []*Connection {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -79,6 +106,9 @@ func (p *Pool) Connections() []*Connection {
 func (p *Pool) Get() (*Connection, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	if p.isClosed {
+		return nil, errors.New("pool is closed")
+	}
 
 	if p.connections == nil || len(p.connections) == 0 {
 		return nil, errors.New("no connections in the pool")
@@ -95,8 +125,8 @@ func (p *Pool) Get() (*Connection, error) {
 	return conn, nil
 }
 
-// when connection is closed pool will remove it from the pool of connections
-// and will start goroutine to create new connection for the address
+// when connection is closed, remove it from the pool of connections and start
+// goroutine to create new connection for the same address
 func (p *Pool) handleClosedConnection(closedConn *Connection) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -110,8 +140,8 @@ func (p *Pool) handleClosedConnection(closedConn *Connection) {
 	}
 
 	// somehow we didn't find closed connection in the pool
-	// TODO: notify about error
 	if connIndex < 0 {
+		p.handleError(errors.New("closed connection was not found in the pool"))
 		return
 	}
 
@@ -119,35 +149,41 @@ func (p *Pool) handleClosedConnection(closedConn *Connection) {
 	p.connections[len(p.connections)-1] = nil                      // Erase last element
 	p.connections = p.connections[:len(p.connections)-1]           // Truncate slice.
 
+	// if pool was closed, don't start recreate goroutine
+	// should we return earlier and keep connection in the pool as it will be closed anyway?
+	if p.isClosed {
+		return
+	}
+
 	// initiate goroutine to reconnect to closedConn.Addr
+	p.wg.Add(1)
 	go p.recreateConnection(closedConn)
 }
 
 func (p *Pool) recreateConnection(closedConn *Connection) {
-	<-time.After(100 * time.Millisecond)
+	defer p.wg.Done()
+
 	conn, err := p.Factory(closedConn.Addr)
 	if err != nil {
-		// TODO ups, no way to notify about errors...
-		log.Printf("failed to re-create connection for %s: %s", closedConn.Addr, err)
+		p.handleError(fmt.Errorf("failed to re-create connection for %s: %w", closedConn.Addr, err))
 		return
 	}
 
+	// set own handler when connection is closed
+	conn.SetOptions(ConnectionClosedHandler(p.handleClosedConnection))
+
 	for {
-		fmt.Println("loop until err != nil")
-		fmt.Println("connecting...")
 		err = conn.Connect()
 		if err == nil {
 			break
 		}
-		fmt.Println("connected")
 
-		log.Printf("failed to re-connect to %s: %s", conn.Addr, err)
+		p.handleError(fmt.Errorf("failed to reconnect to %s: %w", conn.Addr, err))
 		select {
-		case <-time.After(5 * time.Second):
-			// wait for 5 seconds before the next attemp to connect
+		case <-time.After(p.Opts.ReconnectWait):
 			continue
 		case <-p.Done():
-			// if pool is closed, let's get our of here
+			// if pool is closed, let's get out of here
 			return
 		}
 	}
@@ -155,14 +191,38 @@ func (p *Pool) recreateConnection(closedConn *Connection) {
 	p.mu.Lock()
 	p.connections = append(p.connections, conn)
 	p.mu.Unlock()
-	// we should stop trying if pool is closed
-	// we should stop trying after N attempts (-1 continue endlessly)
-	// we should wait before reconnects
 }
 
 // Close closes all connections in the pool
 func (p *Pool) Close() error {
+	p.mu.Lock()
+	if p.isClosed {
+		p.mu.Unlock()
+		return nil
+	}
+	p.isClosed = true
+	p.mu.Unlock()
+
 	close(p.done)
+
+	// wait for all re-connection goroutines to stop
+	// they may add more connections to the pool
+	// so we want to be sure that no new connections will appear
+	// when we lock and start closing all connections
+	p.wg.Wait()
+
+	// close all connections concurrently
+	p.mu.Lock()
+	for _, conn := range p.connections {
+		err := conn.Close()
+		if err != nil {
+			p.handleError(fmt.Errorf("closing connection on pool close: %w", err))
+		}
+	}
+
+	// remove all connections
+	p.connections = make([]*Connection, 0)
+	p.mu.Unlock()
 
 	return nil
 }

--- a/pool.go
+++ b/pool.go
@@ -108,7 +108,6 @@ type FilterFunc func(*Connection) bool
 
 // Get returns filtered connection from the pool
 func (p *Pool) Get() (*Connection, error) {
-	fmt.Println("Get")
 	p.mu.Lock()
 	if p.isClosed {
 		p.mu.Unlock()

--- a/pool.go
+++ b/pool.go
@@ -218,13 +218,13 @@ func (p *Pool) Close() error {
 	wg.Add(len(p.connections))
 
 	for _, conn := range p.connections {
-		go func() {
+		go func(conn *Connection) {
 			defer wg.Done()
 			err := conn.Close()
 			if err != nil {
 				p.handleError(fmt.Errorf("closing connection on pool close: %w", err))
 			}
-		}()
+		}(conn)
 
 	}
 	wg.Wait()

--- a/pool.go
+++ b/pool.go
@@ -74,7 +74,7 @@ func (p *Pool) Connect() error {
 
 		err = conn.Connect()
 		if err != nil {
-			p.handleError(fmt.Errorf("connecting to %s: %w", conn.Addr, err))
+			p.handleError(fmt.Errorf("connecting to %s: %w", conn.addr, err))
 			p.wg.Add(1)
 			go p.recreateConnection(conn)
 			continue
@@ -185,9 +185,9 @@ func (p *Pool) recreateConnection(closedConn *Connection) {
 	var err error
 	for {
 
-		conn, err = p.Factory(closedConn.Addr)
+		conn, err = p.Factory(closedConn.addr)
 		if err != nil {
-			p.handleError(fmt.Errorf("failed to re-create connection for %s: %w", closedConn.Addr, err))
+			p.handleError(fmt.Errorf("failed to re-create connection for %s: %w", closedConn.addr, err))
 			return
 		}
 
@@ -200,7 +200,7 @@ func (p *Pool) recreateConnection(closedConn *Connection) {
 			break
 		}
 
-		p.handleError(fmt.Errorf("failed to reconnect to %s: %w", conn.Addr, err))
+		p.handleError(fmt.Errorf("failed to reconnect to %s: %w", conn.addr, err))
 		select {
 		case <-time.After(p.Opts.ReconnectWait):
 			continue

--- a/pool.go
+++ b/pool.go
@@ -1,0 +1,172 @@
+package connection
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+)
+
+type ConnectionFactoryFunc func(addr string) (*Connection, error)
+
+type Pool struct {
+	Factory ConnectionFactoryFunc
+	Addrs   []string
+
+	mu          sync.Mutex
+	connections []*Connection
+	connIndex   int
+
+	done chan struct{}
+}
+
+// Pool - provides connection to the clients. It checks the health of the
+// connection and if connection is not healthy it removes it from the pool and
+// in the background will try to create new connection so pool will be full.
+// Pool needs a list of IP addresses (connection configs) to create connections for.
+
+func NewPool(factory ConnectionFactoryFunc, addrs []string) *Pool {
+	// fill the connection pool
+	// check health of the connections in the goroutine
+
+	return &Pool{
+		Factory: factory,
+		Addrs:   addrs,
+		done:    make(chan struct{}),
+	}
+}
+
+// Connect creates poll of connections by calling Factory method and connect them all
+func (p *Pool) Connect() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// build connections
+	for _, addr := range p.Addrs {
+		conn, err := p.Factory(addr)
+		if err != nil {
+			return fmt.Errorf("creating connection for %s: %w", addr, err)
+		}
+
+		// set own handler when connection is closed
+		conn.SetOptions(ConnectionClosedHandler(p.handleClosedConnection))
+
+		err = conn.Connect()
+		if err != nil {
+			return fmt.Errorf("connecting to %s: %w", conn.Addr, err)
+		}
+
+		p.connections = append(p.connections, conn)
+	}
+
+	return nil
+}
+
+// Get returns connection from the pool
+func (p *Pool) Connections() []*Connection {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// create new slice, as p.connections can be changed
+	var conns []*Connection
+	conns = append(conns, p.connections...)
+
+	return conns
+}
+
+// Get returns connection from the pool
+func (p *Pool) Get() (*Connection, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.connections == nil || len(p.connections) == 0 {
+		return nil, errors.New("no connections in the pool")
+	}
+
+	conn := p.connections[p.connIndex]
+	p.connIndex++
+
+	// reset index
+	if p.connIndex >= len(p.connections) {
+		p.connIndex = 0
+	}
+
+	return conn, nil
+}
+
+// when connection is closed pool will remove it from the pool of connections
+// and will start goroutine to create new connection for the address
+func (p *Pool) handleClosedConnection(closedConn *Connection) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	var connIndex = -1
+	for i, conn := range p.connections {
+		if conn == closedConn {
+			connIndex = i
+			break
+		}
+	}
+
+	// somehow we didn't find closed connection in the pool
+	// TODO: notify about error
+	if connIndex < 0 {
+		return
+	}
+
+	p.connections[connIndex] = p.connections[len(p.connections)-1] // Copy last element to index connIndex.
+	p.connections[len(p.connections)-1] = nil                      // Erase last element
+	p.connections = p.connections[:len(p.connections)-1]           // Truncate slice.
+
+	// initiate goroutine to reconnect to closedConn.Addr
+	go p.recreateConnection(closedConn)
+}
+
+func (p *Pool) recreateConnection(closedConn *Connection) {
+	<-time.After(100 * time.Millisecond)
+	conn, err := p.Factory(closedConn.Addr)
+	if err != nil {
+		// TODO ups, no way to notify about errors...
+		log.Printf("failed to re-create connection for %s: %s", closedConn.Addr, err)
+		return
+	}
+
+	for {
+		fmt.Println("loop until err != nil")
+		fmt.Println("connecting...")
+		err = conn.Connect()
+		if err == nil {
+			break
+		}
+		fmt.Println("connected")
+
+		log.Printf("failed to re-connect to %s: %s", conn.Addr, err)
+		select {
+		case <-time.After(5 * time.Second):
+			// wait for 5 seconds before the next attemp to connect
+			continue
+		case <-p.Done():
+			// if pool is closed, let's get our of here
+			return
+		}
+	}
+
+	p.mu.Lock()
+	p.connections = append(p.connections, conn)
+	p.mu.Unlock()
+	// we should stop trying if pool is closed
+	// we should stop trying after N attempts (-1 continue endlessly)
+	// we should wait before reconnects
+}
+
+// Close closes all connections in the pool
+func (p *Pool) Close() error {
+	close(p.done)
+
+	return nil
+}
+
+func (p *Pool) Done() <-chan struct{} {
+	return p.done
+}

--- a/pool_options.go
+++ b/pool_options.go
@@ -1,0 +1,48 @@
+package connection
+
+import (
+	"time"
+)
+
+type PoolOption func(*PoolOptions) error
+
+type PoolOptions struct {
+	// ReconnectWait sets the time to wait after first re-connect attempt
+	ReconnectWait time.Duration
+
+	// ErrorHandler is called in a goroutine with the errors that can't be
+	// returned to the caller
+	ErrorHandler func(err error)
+
+	// MinConnections is the number of connections required to be established when
+	// we connect the pool
+	MinConnections int
+}
+
+func GetDefaultPoolOptions() PoolOptions {
+	return PoolOptions{
+		ReconnectWait:  5 * time.Second,
+		MinConnections: 1,
+	}
+}
+
+func PoolReconnectWait(rw time.Duration) PoolOption {
+	return func(opts *PoolOptions) error {
+		opts.ReconnectWait = rw
+		return nil
+	}
+}
+
+func PoolMinConnections(n int) PoolOption {
+	return func(opts *PoolOptions) error {
+		opts.MinConnections = n
+		return nil
+	}
+}
+
+func PoolErrorHandler(h func(err error)) PoolOption {
+	return func(opts *PoolOptions) error {
+		opts.ErrorHandler = h
+		return nil
+	}
+}

--- a/pool_options.go
+++ b/pool_options.go
@@ -50,9 +50,9 @@ func PoolErrorHandler(h func(err error)) PoolOption {
 	}
 }
 
-// OnConnect sets a callback that will be synchronously  called when connection is established.
+// PoolOnConnect sets a callback that will be synchronously  called when connection is established.
 // If it returns error, then connections will be closed and re-connect will be attempted
-func OnConnect(h func(c *Connection) error) PoolOption {
+func PoolOnConnect(h func(c *Connection) error) PoolOption {
 	return func(opts *PoolOptions) error {
 		opts.OnConnect = h
 		return nil

--- a/pool_options.go
+++ b/pool_options.go
@@ -17,9 +17,6 @@ type PoolOptions struct {
 	// MinConnections is the number of connections required to be established when
 	// we connect the pool
 	MinConnections int
-
-	// OnConnect is called synchronously when a connection is established
-	OnConnect func(c *Connection) error
 }
 
 func GetDefaultPoolOptions() PoolOptions {
@@ -46,15 +43,6 @@ func PoolMinConnections(n int) PoolOption {
 func PoolErrorHandler(h func(err error)) PoolOption {
 	return func(opts *PoolOptions) error {
 		opts.ErrorHandler = h
-		return nil
-	}
-}
-
-// PoolOnConnect sets a callback that will be synchronously  called when connection is established.
-// If it returns error, then connections will be closed and re-connect will be attempted
-func PoolOnConnect(h func(c *Connection) error) PoolOption {
-	return func(opts *PoolOptions) error {
-		opts.OnConnect = h
 		return nil
 	}
 }

--- a/pool_options.go
+++ b/pool_options.go
@@ -17,6 +17,10 @@ type PoolOptions struct {
 	// MinConnections is the number of connections required to be established when
 	// we connect the pool
 	MinConnections int
+
+	// ConntionsFilter is a function to filter connections in the pool
+	// when Get() is called
+	ConnectionsFilter func(*Connection) bool
 }
 
 func GetDefaultPoolOptions() PoolOptions {
@@ -43,6 +47,13 @@ func PoolMinConnections(n int) PoolOption {
 func PoolErrorHandler(h func(err error)) PoolOption {
 	return func(opts *PoolOptions) error {
 		opts.ErrorHandler = h
+		return nil
+	}
+}
+
+func PoolConnectionsFilter(f func(*Connection) bool) PoolOption {
+	return func(opts *PoolOptions) error {
+		opts.ConnectionsFilter = f
 		return nil
 	}
 }

--- a/pool_options.go
+++ b/pool_options.go
@@ -17,6 +17,9 @@ type PoolOptions struct {
 	// MinConnections is the number of connections required to be established when
 	// we connect the pool
 	MinConnections int
+
+	// OnConnect is called synchronously when a connection is established
+	OnConnect func(c *Connection) error
 }
 
 func GetDefaultPoolOptions() PoolOptions {
@@ -43,6 +46,15 @@ func PoolMinConnections(n int) PoolOption {
 func PoolErrorHandler(h func(err error)) PoolOption {
 	return func(opts *PoolOptions) error {
 		opts.ErrorHandler = h
+		return nil
+	}
+}
+
+// OnConnect sets a callback that will be synchronously  called when connection is established.
+// If it returns error, then connections will be closed and re-connect will be attempted
+func OnConnect(h func(c *Connection) error) PoolOption {
+	return func(opts *PoolOptions) error {
+		opts.OnConnect = h
 		return nil
 	}
 }

--- a/pool_test.go
+++ b/pool_test.go
@@ -95,7 +95,7 @@ func TestPool(t *testing.T) {
 		require.Len(t, pool.Connections(), serversToStart)
 	})
 
-	t.Run("Get() returns next connection from the pool looping over the list of connections", func(t *testing.T) {
+	t.Run("Get returns next connection from the pool looping over the list of connections", func(t *testing.T) {
 		// When we call Get() len(pool.Connections()) * N times
 		var n = 3
 		var connections []*connection.Connection

--- a/pool_test.go
+++ b/pool_test.go
@@ -219,7 +219,7 @@ func TestPool(t *testing.T) {
 		// keeping second connection with status `offline`
 		onConnect := func(conn *connection.Connection) error {
 			if atomic.AddInt32(&onConnectCalled, 1) == 1 {
-				conn.Set("status", "online")
+				conn.SetStatus(connection.StatusOnline)
 			}
 
 			return nil
@@ -244,7 +244,7 @@ func TestPool(t *testing.T) {
 
 		// filterOnlineConnections returns only connections with status `online`
 		filterOnlineConnections := func(conn *connection.Connection) bool {
-			return conn.Get("status") == "online"
+			return conn.Status() == connection.StatusOnline
 		}
 
 		pool, err := connection.NewPool(
@@ -265,7 +265,7 @@ func TestPool(t *testing.T) {
 		// Get should return the same connection twice (filter not `online` connections)
 		conn, err := pool.Get()
 		require.NoError(t, err)
-		require.Equal(t, conn.Get("status"), "online")
+		require.Equal(t, conn.Status(), connection.StatusOnline)
 
 		// Get should return the same connection as the first one (filter not `online` connections)
 		for i := 0; i < serversToStart; i++ {

--- a/pool_test.go
+++ b/pool_test.go
@@ -77,6 +77,9 @@ func TestPool(t *testing.T) {
 	require.NoError(t, err)
 	defer pool.Close()
 
+	// pool is Down by default
+	require.False(t, pool.IsUp())
+
 	t.Run("Connect() establishes connections to all servers", func(t *testing.T) {
 		// When we Connect pool
 		err := pool.Connect()

--- a/pool_test.go
+++ b/pool_test.go
@@ -225,7 +225,7 @@ func TestPool(t *testing.T) {
 			return errors.New("onConnect error")
 		}
 
-		pool, err := connection.NewPool(factory, addrs, connection.OnConnect(onConnect))
+		pool, err := connection.NewPool(factory, addrs, connection.PoolOnConnect(onConnect))
 		require.NoError(t, err)
 
 		err = pool.Connect()

--- a/pool_test.go
+++ b/pool_test.go
@@ -270,5 +270,8 @@ func TestPool(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, conn, connN)
 		}
+
+		// should be degraded
+		require.True(t, pool.IsDegraded())
 	})
 }

--- a/pool_test.go
+++ b/pool_test.go
@@ -12,10 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TODO
-// pass retries, wait time, etc.
-// new Pool should have callback for when it was closed (when all connections were closed)
-// Pool when it creates connection from factory should set own handler for closed connection
 func TestPool(t *testing.T) {
 	// Given
 	// servers started

--- a/pool_test.go
+++ b/pool_test.go
@@ -1,0 +1,176 @@
+package connection_test
+
+import (
+	"fmt"
+	"net"
+	"sync/atomic"
+	"testing"
+
+	"time"
+
+	"github.com/moov-io/iso8583"
+	connection "github.com/moov-io/iso8583-connection"
+	"github.com/moov-io/iso8583/field"
+	"github.com/stretchr/testify/require"
+)
+
+// TODO
+// pass retries, wait time, etc.
+// new Pool should have callback for when it was closed (when all connections were closed)
+// Pool when it creates connection from factory should set own handler for closed connection
+func TestPool(t *testing.T) {
+	// Given
+	// servers started
+	var servers []*testServer
+
+	// servers to start
+	serversToStart := 2
+	// list of addresses of the servers
+	var addrs []string
+	// each server on connect will increment connectionsCnt counter
+	var connectionsCnt int32
+	// start all servers
+	for i := 0; i < serversToStart; i++ {
+		server, err := NewTestServer()
+		require.NoError(t, err)
+		defer server.Close()
+
+		addrs = append(addrs, server.Addr)
+		servers = append(servers, server)
+
+		// increase counter when server receives connection
+		server.Server.AddConnectionHandler(func(_ net.Conn) {
+			atomic.AddInt32(&connectionsCnt, 1)
+		})
+	}
+
+	// And a factory method that will build connection for the pool
+	factory := func(addr string) (*connection.Connection, error) {
+		// all our addresses have same configs, but if you need to use
+		// different TLS config, you can define config out of this
+		// function like:
+		// tlsConfigs := map[string]*tls.Config{
+		// 	"127.0.0.1": &tls.Config{},
+		// 	"127.0.0.2": &tls.Config{},
+		// }
+		// and inside factory, just pick your config based on the address
+		// tlsConfig := tlsConfigs[addr]
+
+		opts := []connection.Option{
+			connection.SendTimeout(5 * time.Second),
+			connection.IdleTime(5 * time.Second),
+		}
+
+		c, err := connection.New(
+			addr,
+			testSpec,
+			readMessageLength,
+			writeMessageLength,
+			opts...,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("building iso 8583 connection: %w", err)
+		}
+
+		return c, nil
+	}
+
+	// And the pool of connections
+	pool := connection.NewPool(factory, addrs)
+
+	t.Run("Connect() establishes all connections", func(t *testing.T) {
+		// When we Connect pool
+		err := pool.Connect()
+		require.NoError(t, err)
+
+		// Then pool builds and connects connections to all servers
+		require.Eventually(t, func() bool {
+			// we expect connectionsCnt counter to be incremented by both servers
+			return connectionsCnt == int32(serversToStart)
+		}, 500*time.Millisecond, 50*time.Millisecond, "%d expected connections established, but got %d", serversToStart, connectionsCnt)
+
+		// And pool has serversCnt connections
+		require.Len(t, pool.Connections(), serversToStart)
+	})
+
+	t.Run("Get() returns next connection from the pool looping over the list of connections", func(t *testing.T) {
+		// When we call Get() len(pool.Connections()) * N times
+		var n = 3
+		var connections []*connection.Connection
+		for i := 0; i < len(pool.Connections())*n; i++ {
+			conn, err := pool.Get()
+			require.NoError(t, err)
+			connections = append(connections, conn)
+		}
+
+		// Then each connection should be returned N times
+		counter := map[*connection.Connection]int{}
+		for _, conn := range connections {
+			if conn == nil {
+				continue
+			}
+			counter[conn]++
+		}
+
+		require.NotEmpty(t, counter)
+
+		for _, returns := range counter {
+			require.Equal(t, n, returns)
+		}
+	})
+
+	t.Run("when one of the connections is closed it creates new connection for the same address", func(t *testing.T) {
+		numOfConnectionsBeforeClose := len(pool.Connections())
+
+		// trigger server to close connection
+		message := iso8583.NewMessage(testSpec)
+		err := message.Marshal(baseFields{
+			MTI:          field.NewStringValue("0800"),
+			TestCaseCode: field.NewStringValue(TestCaseCloseConnection),
+			STAN:         field.NewStringValue(getSTAN()),
+		})
+		require.NoError(t, err)
+
+		conn, err := pool.Get()
+		require.NoError(t, err)
+
+		_, err = conn.Send(message)
+		require.NoError(t, err)
+
+		connectionsCntBeforeReConnect := connectionsCnt
+
+		// let our pool to detect closed connection and remove it from the pool
+		require.Eventually(t, func() bool {
+			return len(pool.Connections()) == numOfConnectionsBeforeClose-1
+		}, 500*time.Millisecond, 50*time.Millisecond, "expected one less connection, total %d connections, expected: %d", len(pool.Connections()), numOfConnectionsBeforeClose-1)
+
+		// Then pool should recreate connection after p.WaitBeforeReconnect
+		require.Eventually(t, func() bool {
+			// we expect connectionsCnt counter to be incremented by both servers
+			return connectionsCnt == connectionsCntBeforeReConnect+1
+		}, 500*time.Millisecond, 50*time.Millisecond, "expected %d connections count, but got %d", connectionsCntBeforeReConnect+1, connectionsCnt)
+
+		// And pool has serversCnt connections
+		require.Len(t, pool.Connections(), serversToStart)
+
+		// let's close first server - we should see how we try to re-connect
+		servers[0].Close()
+
+		time.Sleep(20 * time.Second)
+	})
+
+	t.Run("when all connections are closed it calls ConnectionsClosedHandler", func(t *testing.T) {
+	})
+
+	// close them concurrently
+	t.Run("Close() closes all connections", func(t *testing.T) {
+
+	})
+
+	// when no connections, Get returns error ErrorEmptyPool
+
+	// when pool is closed
+	t.Run("Get() returns error ErrorPoolClosed", func(t *testing.T) {})
+	t.Run("Connections() returns empty slice", func(t *testing.T) {})
+	t.Run("Connect() establishes all coonnections", func(t *testing.T) {})
+}

--- a/server/server.go
+++ b/server/server.go
@@ -9,6 +9,8 @@ import (
 	connection "github.com/moov-io/iso8583-connection"
 )
 
+type ConnectHandler func(conn net.Conn)
+
 // Server is a simple iso8583 server implementation currently used to test
 // iso8583-client and most probably to be used for iso8583-test-harness
 type Server struct {
@@ -29,6 +31,10 @@ type Server struct {
 	// writeMessageLength is the function that encodes message length and
 	// writes message length header into the connection
 	writeMessageLength connection.MessageLengthWriter
+
+	mu              sync.Mutex
+	ConnectHandlers []ConnectHandler
+	isClosed        bool
 }
 
 func New(spec *iso8583.MessageSpec, mlReader connection.MessageLengthReader, mlWriter connection.MessageLengthWriter, connectionOpts ...connection.Option) *Server {
@@ -40,6 +46,12 @@ func New(spec *iso8583.MessageSpec, mlReader connection.MessageLengthReader, mlW
 		readMessageLength:  mlReader,
 		writeMessageLength: mlWriter,
 	}
+}
+
+func (s *Server) AddConnectionHandler(h ConnectHandler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ConnectHandlers = append(s.ConnectHandlers, h)
 }
 
 func (s *Server) Start(addr string) error {
@@ -73,6 +85,15 @@ func (s *Server) Start(addr string) error {
 
 			s.wg.Add(1)
 			go func() {
+				// notify all handlers about new connection
+				s.mu.Lock()
+				if s.ConnectHandlers != nil && len(s.ConnectHandlers) > 0 {
+					for _, h := range s.ConnectHandlers {
+						go h(conn)
+					}
+				}
+				defer s.mu.Unlock()
+
 				err := s.handleConnection(conn)
 				if err != nil {
 					fmt.Printf("Error handling connection: %s\n", err.Error())
@@ -86,6 +107,12 @@ func (s *Server) Start(addr string) error {
 }
 
 func (s *Server) Close() {
+	s.mu.Lock()
+	if s.isClosed {
+		s.mu.Unlock()
+		return
+	}
+
 	close(s.closeCh)
 
 	if s.ln != nil {
@@ -93,6 +120,8 @@ func (s *Server) Close() {
 	}
 
 	s.wg.Wait()
+
+	s.isClosed = true
 }
 
 func (s *Server) handleConnection(conn net.Conn) error {


### PR DESCRIPTION
The goal of this PR is to add a connection pool that will handle connection, reconnection, and other aspects of multiple connections.

It allows to:
* configure each connection separately
* start with 1 of N connections and start re-create process for failed connections
* re-create connections closed by server waiting for `ReconnectWait` before next attempt
* get connections in round-robin filtered (by address, key/value, etc.)