### PR TITLE
Allow to handle connection status

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -75,6 +75,9 @@ type Connection struct {
 
 	// user has called Close
 	closing bool
+
+	// artibtrary status set by user such as "online", "down", "etc.)
+	status Status
 }
 
 // New creates and configures Connection. To establish network connection, call `Connect()`.
@@ -576,4 +579,18 @@ func (c *Connection) handleResponse(rawMessage []byte) {
 			go c.Opts.InboundMessageHandler(c, message)
 		}
 	}
+}
+
+func (c *Connection) Status() Status {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	return c.status
+}
+
+func (c *Connection) SetStatus(status Status) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.status = status
 }

--- a/connection.go
+++ b/connection.go
@@ -76,7 +76,7 @@ type Connection struct {
 	// user has called Close
 	closing bool
 
-	// artibtrary status set by user such as "online", "down", "etc.)
+	// arbitrary status set by user such as "online", "down", etc.
 	status Status
 }
 
@@ -149,6 +149,10 @@ func (c *Connection) Connect() error {
 	c.conn = conn
 
 	c.run()
+
+	if c.Opts.ConnectionEstablishedHandler != nil {
+		go c.Opts.ConnectionEstablishedHandler(c)
+	}
 
 	return nil
 }

--- a/connection.go
+++ b/connection.go
@@ -76,8 +76,8 @@ type Connection struct {
 	// user has called Close
 	closing bool
 
-	// arbitrary status set by user such as "online", "down", etc.
-	status Status
+	// kv stores brand specific data such as status of the connection
+	kv map[string]string
 }
 
 // New creates and configures Connection. To establish network connection, call `Connect()`.
@@ -99,6 +99,7 @@ func New(addr string, spec *iso8583.MessageSpec, mlReader MessageLengthReader, m
 		spec:               spec,
 		readMessageLength:  mlReader,
 		writeMessageLength: mlWriter,
+		kv:                 make(map[string]string),
 	}, nil
 }
 
@@ -585,16 +586,22 @@ func (c *Connection) handleResponse(rawMessage []byte) {
 	}
 }
 
-func (c *Connection) Status() Status {
+// Get returns value by key
+func (c *Connection) Get(key string) string {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	return c.status
+	if value, ok := c.kv[key]; ok {
+		return value
+	}
+
+	return ""
 }
 
-func (c *Connection) SetStatus(status Status) {
+// Set sets value by key
+func (c *Connection) Set(key, value string) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	c.status = status
+	c.kv[key] = value
 }

--- a/connection_test.go
+++ b/connection_test.go
@@ -839,14 +839,23 @@ func TestClient_Options(t *testing.T) {
 	})
 }
 
-func TestConnectionStatus(t *testing.T) {
-	c, err := connection.New("1.1.1.1", nil, nil, nil)
+func TestConnection(t *testing.T) {
+	t.Run("Get", func(t *testing.T) {
+		c, err := connection.New("1.1.1.1", nil, nil, nil)
 
-	require.NoError(t, err)
-	require.Empty(t, c.Status())
+		require.NoError(t, err)
+		require.Empty(t, c.Get("status"))
+	})
 
-	c.SetStatus(connection.StatusOnline)
-	require.Equal(t, connection.StatusOnline, c.Status())
+	// test Set for connection
+	t.Run("Set", func(t *testing.T) {
+		c, err := connection.New("1.1.1.1", nil, nil, nil)
+
+		require.NoError(t, err)
+
+		c.Set("status", "connected")
+		require.Equal(t, "connected", c.Get("status"))
+	})
 }
 
 type TrackingRWCloser struct{ Used bool }

--- a/connection_test.go
+++ b/connection_test.go
@@ -803,6 +803,16 @@ func TestClient_Options(t *testing.T) {
 	})
 }
 
+func TestConnectionStatus(t *testing.T) {
+	c, err := connection.New("1.1.1.1", nil, nil, nil)
+
+	require.NoError(t, err)
+	require.Empty(t, c.Status())
+
+	c.SetStatus(connection.StatusOnline)
+	require.Equal(t, connection.StatusOnline, c.Status())
+}
+
 type TrackingRWCloser struct{ Used bool }
 
 func (m *TrackingRWCloser) Write(p []byte) (n int, err error) {

--- a/options.go
+++ b/options.go
@@ -42,6 +42,10 @@ type Options struct {
 	// were network errors during network read/write
 	ConnectionClosedHandler func(c *Connection)
 
+	// ConnectionEstablishedHandler is called when connection is
+	// established with the server
+	ConnectionEstablishedHandler func(c *Connection)
+
 	TLSConfig *tls.Config
 
 	// ErrorHandler is called in a goroutine with the errors that can't be
@@ -105,6 +109,13 @@ func PingHandler(handler func(c *Connection)) Option {
 func ConnectionClosedHandler(handler func(c *Connection)) Option {
 	return func(o *Options) error {
 		o.ConnectionClosedHandler = handler
+		return nil
+	}
+}
+
+func ConnectionEstablishedHandler(handler func(c *Connection)) Option {
+	return func(o *Options) error {
+		o.ConnectionEstablishedHandler = handler
 		return nil
 	}
 }

--- a/status.go
+++ b/status.go
@@ -1,0 +1,8 @@
+package connection
+
+type Status string
+
+const (
+	StatusOnline  Status = "online"
+	StatusOffline Status = "offline"
+)

--- a/status.go
+++ b/status.go
@@ -1,8 +1,0 @@
-package connection
-
-type Status string
-
-const (
-	StatusOnline  Status = "online"
-	StatusOffline Status = "offline"
-)


### PR DESCRIPTION
What:
* allow to set/get key-valye for the connection using `c.Set(key, value)` and `c.Get(key)`
* add `ConnectionEstablishedHandler` which is called when connection is established

Why:
* move status logic out of the brand specific clients into the Connection
* clients of `connection.Pool` need a way to set connection status when connection is established
* clients of `connection.Pool` need a way to get connections filtered by status (e.g., only online connections)
