### PR TITLE
Add connection Reconnect method

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.19
+        go-version: ^1.19.1
       id: go
 
     - name: Check out code into the Go module directory

--- a/connection.go
+++ b/connection.go
@@ -141,6 +141,16 @@ func (c *Connection) Connect() error {
 
 // Reconnect establishes a new connection to the server using configured Addr
 func (c *Connection) Reconnect() error {
+	c.mutex.Lock()
+
+	if c.reconnecting {
+		c.mutex.Unlock()
+		return nil
+	}
+
+	c.reconnecting = true
+	c.mutex.Unlock()
+
 	// Should only be called on non-active channels, this adds additional protections
 	err := c.Close()
 	if err != nil {

--- a/connection.go
+++ b/connection.go
@@ -268,13 +268,15 @@ func (c *Connection) close() error {
 // connection with ISO 8583 server
 func (c *Connection) Close() error {
 	c.mutex.Lock()
+	defer func() {
+		c.mutex.Unlock()
+	}()
 	// if we are closing already, just return
 	if c.closing {
-		c.mutex.Unlock()
 		return nil
 	}
+
 	c.closing = true
-	c.mutex.Unlock()
 
 	return c.close()
 }

--- a/connection_test.go
+++ b/connection_test.go
@@ -120,6 +120,41 @@ func TestClient_Connect(t *testing.T) {
 	})
 }
 
+func TestClient_Reconnect(t *testing.T) {
+	t.Run("reconnect called on new (never connected) connection", func(t *testing.T) {
+		server, err := NewTestServer()
+		require.NoError(t, err)
+		defer server.Close()
+
+		// our client can connect to the server
+		c, err := connection.New(server.Addr, testSpec, readMessageLength, writeMessageLength)
+		require.NoError(t, err)
+
+		err = c.Reconnect()
+		require.NoError(t, err)
+		require.NoError(t, c.Close())
+	})
+
+	t.Run("reconnect called on closed connection", func(t *testing.T) {
+		server, err := NewTestServer()
+		require.NoError(t, err)
+		defer server.Close()
+
+		// our client can connect to the server
+		c, err := connection.New(server.Addr, testSpec, readMessageLength, writeMessageLength)
+		require.NoError(t, err)
+
+		err = c.Connect()
+		require.NoError(t, err)
+		err = c.Close()
+		require.NoError(t, err)
+
+		err = c.Reconnect()
+		require.NoError(t, err)
+		require.NoError(t, c.Close())
+	})
+}
+
 func TestClient_Send(t *testing.T) {
 	server, err := NewTestServer()
 	require.NoError(t, err)


### PR DESCRIPTION
Currently if a connection goes offline, there is no way to re-estalbish this entire connection because the Connect method will see the existing net.Conn object in c.conn [on these lines ](https://github.com/moov-io/iso8583-connection/blob/master/connection.go#L131-L134)and use the existing (and closed) connection.