### PR TITLE
remove DefaultTransmissionDateTimeFormat constant

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -20,8 +20,6 @@ var (
 	ErrSendTimeout      = errors.New("message send timeout")
 )
 
-const DefaultTransmissionDateTimeFormat string = "0102150405" // YYMMDDhhmmss
-
 // MessageLengthReader reads message header from the r and returns message length
 type MessageLengthReader func(r io.Reader) (int, error)
 


### PR DESCRIPTION
instead of https://github.com/moov-io/iso8583-connection/pull/37 let's just remove the unused constant

fixes https://github.com/moov-io/iso8583-connection/issues/36