### PR TITLE
add RequestIDGenerator interface to allow custom implementations

### DIFF
--- a/options.go
+++ b/options.go
@@ -60,18 +60,23 @@ type Options struct {
 
 	// OnClose is called synchronously before a connection is closed
 	OnClose func(c *Connection) error
+
+	// RequestIDGenerator is used to generate a unique identifier for a request
+	// so that responses from the server can be matched to the original request.
+	RequestIDGenerator RequestIDGenerator
 }
 
 type Option func(*Options) error
 
 func GetDefaultOptions() Options {
 	return Options{
-		ConnectTimeout: 10 * time.Second,
-		SendTimeout:    30 * time.Second,
-		IdleTime:       5 * time.Second,
-		ReadTimeout:    60 * time.Second,
-		PingHandler:    nil,
-		TLSConfig:      nil,
+		ConnectTimeout:     10 * time.Second,
+		SendTimeout:        30 * time.Second,
+		IdleTime:           5 * time.Second,
+		ReadTimeout:        60 * time.Second,
+		PingHandler:        nil,
+		TLSConfig:          nil,
+		RequestIDGenerator: &defaultRequestIDGenerator{},
 	}
 }
 
@@ -228,6 +233,14 @@ func SetTLSConfig(cfg func(*tls.Config)) Option {
 			o.TLSConfig = defaultTLSConfig()
 		}
 		cfg(o.TLSConfig)
+		return nil
+	}
+}
+
+// RequestIDGenerator sets a RequestIDGenerator option
+func SetRequestIDGenerator(g RequestIDGenerator) Option {
+	return func(o *Options) error {
+		o.RequestIDGenerator = g
 		return nil
 	}
 }

--- a/request_id_generator.go
+++ b/request_id_generator.go
@@ -1,0 +1,36 @@
+package connection
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/moov-io/iso8583"
+)
+
+// RequestIDGenerator is an interface that generates a unique identifier for a
+// request so that responses from the server can be matched to the original
+// request.
+type RequestIDGenerator interface {
+	GenerateRequestID(msg *iso8583.Message) (string, error)
+}
+
+// defaultRequestIDGenerator is the default implementation of RequestIDGenerator
+// that uses the STAN (field 11) of the message as the request ID.
+type defaultRequestIDGenerator struct{}
+
+func (d *defaultRequestIDGenerator) GenerateRequestID(message *iso8583.Message) (string, error) {
+	if message == nil {
+		return "", fmt.Errorf("message required")
+	}
+
+	stan, err := message.GetString(11)
+	if err != nil {
+		return "", fmt.Errorf("getting STAN (field 11) of the message: %w", err)
+	}
+
+	if stan == "" {
+		return "", errors.New("STAN is missing")
+	}
+
+	return stan, nil
+}


### PR DESCRIPTION
In some cases, you may want to use more than one field (`STAN` in the default request id generator) to match request and response. Such cases are:
* stress load testing when you may handle more that 1 million of transactions within send timeout
* when you implement custom specification that has other field than `11` for the identification and matching purposes

 This PR allows you to set your own request id generator for the connection.