### PR TITLE
Avoid goroutine leak and associated memory leak on specific case

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -356,7 +356,7 @@ func (c *Connection) Send(message *iso8583.Message) (*iso8583.Message, error) {
 	req := request{
 		rawMessage: buf.Bytes(),
 		requestID:  reqID,
-		replyCh:    make(chan *iso8583.Message),
+		replyCh:    make(chan *iso8583.Message, 1),
 		errCh:      make(chan error),
 	}
 

--- a/connection.go
+++ b/connection.go
@@ -356,7 +356,7 @@ func (c *Connection) Send(message *iso8583.Message) (*iso8583.Message, error) {
 	req := request{
 		rawMessage: buf.Bytes(),
 		requestID:  reqID,
-		replyCh:    make(chan *iso8583.Message, 1),
+		replyCh:    make(chan *iso8583.Message),
 		errCh:      make(chan error),
 	}
 


### PR DESCRIPTION
Avoid goroutine leak and associated memory leak on specific case described below:

Is it possible than goroutine in charge of reading the req.replyCh channel will no longer waiting on this channel if:
 - sendTimeoutTimer timer is done; 
 - incoming response message is arrived;
 - before removed requestID on the c.respMap.

So in this cas, goroutine launched by readResponseLoop will be forever blocked (it is goroutine leak) on write into response.replyCh channel.

In order to avoid this situation, it is better to make buffer channel will always accept one write (even if the reader is no longer waiting on read channel).