### PR TITLE
skip messages when length reader return 0 as length

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -149,7 +149,7 @@ func NewTestServerWithAddr(addr string) (*testServer, error) {
 
 			switch code {
 			case TestCaseDelayedResponse:
-				// testing value to "sleep" for a 3 seconds
+				// testing value to "sleep" for 500 ms
 				time.Sleep(500 * time.Millisecond)
 				c.Reply(message)
 			case TestCaseSameSTANRequest:


### PR DESCRIPTION
In certain scenarios, the length header may carry additional information beyond just the length of the message. For instance, it could indicate a rejection message or a keep-alive header. In these cases, the MessageLengthReader may process these internally and return a length of 0, signaling that there is no further message to read.

This PR makes `readLoop` to skip messages if the message length returned by the header reader is `0`. 
