### PR TITLE
Abstract message

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -122,7 +122,14 @@ func NewTestServerWithAddr(addr string) (*testServer, error) {
 	var srv *testServer
 
 	// define logic for our test server
-	testServerLogic := func(c *connection.Connection, message *iso8583.Message) {
+	testServerLogic := func(c *connection.Connection, connMessage connection.Message) {
+		message, ok := connMessage.(*iso8583.Message)
+		if !ok {
+			log.Printf("received message is not *iso8583.Message")
+			log.Printf("received message: %#v", connMessage)
+			return
+		}
+
 		mti, err := message.GetMTI()
 		if err != nil {
 			log.Printf("getting MTI: %s", err.Error())

--- a/message_unpacker.go
+++ b/message_unpacker.go
@@ -1,0 +1,14 @@
+package connection
+
+import "github.com/moov-io/iso8583"
+
+func defaultMessageUnpacker(spec *iso8583.MessageSpec) func([]byte) (Message, error) {
+	return func(rawMessage []byte) (Message, error) {
+		message := iso8583.NewMessage(spec)
+		err := message.Unpack(rawMessage)
+
+		var m Message = message
+
+		return m, err
+	}
+}

--- a/options.go
+++ b/options.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"os"
 	"time"
-
-	"github.com/moov-io/iso8583"
 )
 
 type Options struct {
@@ -39,7 +37,7 @@ type Options struct {
 	// for the following use cases:
 	// * to log timed out responses
 	// * to handle network management messages (echo, heartbeat, etc.)
-	InboundMessageHandler func(c *Connection, message *iso8583.Message)
+	InboundMessageHandler func(c *Connection, message Message)
 
 	// ConnectionClosedHandlers is called when connection is closed by server or there
 	// were network errors during network read/write
@@ -64,6 +62,9 @@ type Options struct {
 	// RequestIDGenerator is used to generate a unique identifier for a request
 	// so that responses from the server can be matched to the original request.
 	RequestIDGenerator RequestIDGenerator
+
+	// MessageUnpacker is used to unpack messages received from the server
+	MessageUnpacker func([]byte) (Message, error)
 }
 
 type Option func(*Options) error
@@ -144,7 +145,7 @@ func ConnectionEstablishedHandler(handler func(c *Connection)) Option {
 }
 
 // InboundMessageHandler sets an InboundMessageHandler option
-func InboundMessageHandler(handler func(c *Connection, message *iso8583.Message)) Option {
+func InboundMessageHandler(handler func(c *Connection, message Message)) Option {
 	return func(o *Options) error {
 		o.InboundMessageHandler = handler
 		return nil

--- a/request_id_generator.go
+++ b/request_id_generator.go
@@ -11,19 +11,24 @@ import (
 // request so that responses from the server can be matched to the original
 // request.
 type RequestIDGenerator interface {
-	GenerateRequestID(msg *iso8583.Message) (string, error)
+	GenerateRequestID(msg Message) (string, error)
 }
 
 // defaultRequestIDGenerator is the default implementation of RequestIDGenerator
 // that uses the STAN (field 11) of the message as the request ID.
 type defaultRequestIDGenerator struct{}
 
-func (d *defaultRequestIDGenerator) GenerateRequestID(message *iso8583.Message) (string, error) {
+func (d *defaultRequestIDGenerator) GenerateRequestID(message Message) (string, error) {
 	if message == nil {
 		return "", fmt.Errorf("message required")
 	}
 
-	stan, err := message.GetString(11)
+	iso8583Message, ok := message.(*iso8583.Message)
+	if !ok {
+		return "", fmt.Errorf("message is not an iso8583.Message")
+	}
+
+	stan, err := iso8583Message.GetString(11)
 	if err != nil {
 		return "", fmt.Errorf("getting STAN (field 11) of the message: %w", err)
 	}


### PR DESCRIPTION
For one of our integrations, message header should be linked to the message as the reply header should contain fields from the request headers.

It's just an experiment to explore options.