### PR TITLE
Make connection to be a writer

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -104,6 +104,8 @@ type Connection struct {
 	status Status
 }
 
+var _ io.Writer = (*Connection)(nil)
+
 // New creates and configures Connection. To establish network connection, call `Connect()`.
 func New(addr string, spec *iso8583.MessageSpec, mlReader MessageLengthReader, mlWriter MessageLengthWriter, options ...Option) (*Connection, error) {
 	opts := GetDefaultOptions()
@@ -192,6 +194,15 @@ func (c *Connection) Connect() error {
 	}
 
 	return nil
+}
+
+// Write writes data directly to the connection. Writes are atomic for
+// net.TCPConn and tls.Conn and can be called simultaneously from multiple
+// goroutines. But you should write whole message (including its header, etc.)
+// at once, don't split one message into multiple Write calls.
+// It's the caller's responsibility to handle the error returned from Write.
+func (c *Connection) Write(p []byte) (int, error) {
+	return c.conn.Write(p)
 }
 
 // run starts read and write loops in goroutines

--- a/connection_test.go
+++ b/connection_test.go
@@ -727,7 +727,7 @@ func TestClient_Send(t *testing.T) {
 
 		c.Reply(msg)
 
-		require.Equal(t, closer.Used, true, "client didn't use custom connection")
+		require.Equal(t, closer.Used(), true, "client didn't use custom connection")
 	})
 
 	// if server closed the connection, we want Send method to receive
@@ -1203,10 +1203,13 @@ func TestConnection(t *testing.T) {
 	})
 }
 
-type TrackingRWCloser struct{ Used bool }
+type TrackingRWCloser struct {
+	used atomic.Bool
+}
 
 func (m *TrackingRWCloser) Write(p []byte) (n int, err error) {
-	m.Used = true
+	m.used.Store(true)
+
 	return 0, nil
 }
 func (m *TrackingRWCloser) Read(p []byte) (n int, err error) {
@@ -1214,6 +1217,10 @@ func (m *TrackingRWCloser) Read(p []byte) (n int, err error) {
 }
 func (m *TrackingRWCloser) Close() error {
 	return nil
+}
+
+func (m *TrackingRWCloser) Used() bool {
+	return m.used.Load()
 }
 
 // interface guard


### PR DESCRIPTION
With this PR we are making it possible to write directly to the network connection.

Why it's may be needed?

Currently, `Connection` is built in a way that it has two loops: read and write to read messages from the connection and to write messages into the connection. These two loops are run in parallel and there is no communication between them. In the end, there are message reader and message writer that work with the network connection.

There are cases, when you may have to handle not only iso8583 messages but additional session/connection information sent by the server you are connected to such as network messages (echo, shutdown, etc.).

In such case, when the message reader reads the network message it should be able to send a reply back. But there is not way for message reader to write data into the connection as it has no access to the writer. Thus, there is a need to expose the `Write` method to make it possible to write data directly to the connection.

Here is an example of how it can be used inside `MessageReader` for the following case:

1. We read network header, which contains data length and the message type
2. If it's a network message, we should handle it separately (let's say echo it back)
3. If it's not a network message, then it's an ISO 8583 message

```go
type messageIO struct {
	connWriter io.Writer
	spec       *iso8583.MessageSpec
}

func (m *messageIO) ReadMessage(r io.Reader) (*iso8583.Message, error) {
	for {
		// read network header
		nh, err := ReadNetworkHeader(r)
		if err != nil {
			return nil, fmt.Errorf("reading network header: %w", err)
		}

		// if network header is for network message (shutdown, echo, etc)
		// then we can handle it
		if nh.IsNetworkMessage() {
			// we can read network message
			m, err := ReadNetworkMessage(r)
			if err != nil {
				return nil, fmt.Errorf("reading network message: %w", err)
			}

			// let's echo back the message with the same network
			// header

			// as Write can be called concurrently we should not
			// split network header and message and write them
			// separately, so we will write them in one operation
			buf := bytes.NewBuffer(nil)
			err = nh.WriteTo(buf)
			if err != nil {
				return nil, fmt.Errorf("writing network header: %w", err)
			}

			err = m.WriteTo(buf)
			if err != nil {
				return nil, fmt.Errorf("writing network message: %w", err)
			}

			// finally write all data in one operation
			// directly to the connection
			_, err = m.connWriter.Write(buf.Bytes())
			if err != nil {
				return nil, fmt.Errorf("writing data: %w", err)
			}

			// continue reading
			continue
		}

		// read regular message here
		data := make([]byte, nh.DataLength)
		_, err = io.ReadFull(r, data)
		if err != nil {
			return nil, fmt.Errorf("reading message data: %w", err)
		}

		// parse message
		message := iso8583.NewMessage(m.Spec)
		err = message.Unpack(data)
		if err != nil {
			return nil, fmt.Errorf("unpacking message: %w", err)
		}

		return message, nil
	}

	return nil, nil
}

func main() {

	messageIO := &messageIO{
		spec: yourSpecHere,
	}

	conn, err := connection.New(addr, nil, nil, nil,
		connection.SetMessageReader(messageIO),
		connection.SetMessageWriter(messageIO),
	)

	messageIO.connWriter = conn
}

```