### PR TITLE
Add keep-alive and NO_DELAY options to Connection

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -159,10 +159,10 @@ func (c *Connection) Connect() error {
 	}
 
 	if tcpConn, ok := conn.(*net.TCPConn); ok {
-		err = tcpConn.SetNoDelay(false)
-	}
-	if err != nil {
-		return fmt.Errorf("setting TCP_NODELAY: %w", err)
+		err = tcpConn.SetNoDelay(c.Opts.NoDelay)
+		if err != nil {
+			return fmt.Errorf("setting TCP_NODELAY: %w", err)
+		}
 	}
 
 	c.conn = conn

--- a/connection.go
+++ b/connection.go
@@ -154,9 +154,15 @@ func (c *Connection) Connect() error {
 	} else {
 		conn, err = d.Dial("tcp", c.addr)
 	}
-
 	if err != nil {
 		return fmt.Errorf("connecting to server %s: %w", c.addr, err)
+	}
+
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		err = tcpConn.SetNoDelay(false)
+	}
+	if err != nil {
+		return fmt.Errorf("setting TCP_NODELAY: %w", err)
 	}
 
 	c.conn = conn

--- a/connection.go
+++ b/connection.go
@@ -142,7 +142,12 @@ func (c *Connection) Connect() error {
 		return nil
 	}
 
-	d := &net.Dialer{Timeout: c.Opts.ConnectTimeout}
+	d := &net.Dialer{
+		Timeout: c.Opts.ConnectTimeout,
+		// The dialer KeepAlive option will set both the time the connection is idle
+		// before probes are sent and the interval between the probes.
+		KeepAlive: c.Opts.KeepAlive,
+	}
 
 	if c.Opts.TLSConfig != nil {
 		conn, err = tls.DialWithDialer(d, "tcp", c.addr, c.Opts.TLSConfig)

--- a/connection_test.go
+++ b/connection_test.go
@@ -186,6 +186,21 @@ func TestClient_Connect(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, c.Close())
 	})
+
+	t.Run("with nodelay disabled", func(t *testing.T) {
+		server, err := NewTestServer()
+		require.NoError(t, err)
+		defer server.Close()
+
+		c, err := connection.New(server.Addr, testSpec, readMessageLength, writeMessageLength,
+			connection.NoDelay(false),
+		)
+		require.NoError(t, err)
+
+		err = c.Connect()
+		require.NoError(t, err)
+		require.NoError(t, c.Close())
+	})
 }
 
 func TestClient_Write(t *testing.T) {

--- a/connection_test.go
+++ b/connection_test.go
@@ -171,6 +171,21 @@ func TestClient_Connect(t *testing.T) {
 			return atomic.LoadInt32(&onClosedCalled) == 1
 		}, 100*time.Millisecond, 20*time.Millisecond, "onClose should be called")
 	})
+
+	t.Run("with keep-alive", func(t *testing.T) {
+		server, err := NewTestServer()
+		require.NoError(t, err)
+		defer server.Close()
+
+		c, err := connection.New(server.Addr, testSpec, readMessageLength, writeMessageLength,
+			connection.KeepAlive(5*time.Second),
+		)
+		require.NoError(t, err)
+
+		err = c.Connect()
+		require.NoError(t, err)
+		require.NoError(t, c.Close())
+	})
 }
 
 func TestClient_Write(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -26,6 +26,10 @@ type Options struct {
 	// ReadTimeoutHandler is called
 	ReadTimeout time.Duration
 
+	// KeepAlive sets the option for keep-alive probes on the underlying connection.
+	// If zero the connection default is used (currently 15s).
+	KeepAlive time.Duration
+
 	// PingHandler is called when no message was sent during idle time
 	// it should be safe for concurrent use
 	PingHandler func(c *Connection)
@@ -91,6 +95,7 @@ func GetDefaultOptions() Options {
 		SendTimeout:        30 * time.Second,
 		IdleTime:           5 * time.Second,
 		ReadTimeout:        60 * time.Second,
+		KeepAlive:          0, // causes the Dialer connection default to be used (currently 15s)
 		PingHandler:        nil,
 		TLSConfig:          nil,
 		RequestIDGenerator: &defaultRequestIDGenerator{},
@@ -125,6 +130,14 @@ func ConnectTimeout(d time.Duration) Option {
 func ReadTimeout(d time.Duration) Option {
 	return func(o *Options) error {
 		o.ReadTimeout = d
+		return nil
+	}
+}
+
+// KeepAlive sets the KeepAlive option
+func KeepAlive(d time.Duration) Option {
+	return func(o *Options) error {
+		o.KeepAlive = d
 		return nil
 	}
 }

--- a/options.go
+++ b/options.go
@@ -30,6 +30,9 @@ type Options struct {
 	// If zero the connection default is used (currently 15s).
 	KeepAlive time.Duration
 
+	// NoDelay sets the option for disabling Nagle's algorithm on the underlying TCP connection.
+	NoDelay bool
+
 	// PingHandler is called when no message was sent during idle time
 	// it should be safe for concurrent use
 	PingHandler func(c *Connection)
@@ -95,7 +98,8 @@ func GetDefaultOptions() Options {
 		SendTimeout:        30 * time.Second,
 		IdleTime:           5 * time.Second,
 		ReadTimeout:        60 * time.Second,
-		KeepAlive:          0, // causes the Dialer connection default to be used (currently 15s)
+		KeepAlive:          0,    // causes the Dialer connection default to be used (currently 15s)
+		NoDelay:            true, // defaulting to true to match Dialer's default behavior
 		PingHandler:        nil,
 		TLSConfig:          nil,
 		RequestIDGenerator: &defaultRequestIDGenerator{},
@@ -138,6 +142,14 @@ func ReadTimeout(d time.Duration) Option {
 func KeepAlive(d time.Duration) Option {
 	return func(o *Options) error {
 		o.KeepAlive = d
+		return nil
+	}
+}
+
+// NoDelay sets the NoDelay option
+func NoDelay(n bool) Option {
+	return func(o *Options) error {
+		o.NoDelay = n
 		return nil
 	}
 }


### PR DESCRIPTION
This PR adds a `KeepAlive` option to `Connection` in order to set the keep-alive options on the underlying TCP connection created by the `Dialer`.

TCP keep-alive packets are zero length packets (just a header) that can be automatically sent and ACK'd on a TCP connection in order to detect issues with the connection when idle. By default Go's `Dialer` will create TCP sockets using a keep-alive time and period of 15 seconds. Some network specs include requirements for keep-alive and so require this setting.

Also added a `NoDelay` setting after some discussion to enable or disable Nagle's algorithm.