### PR TITLE
Add options for send method

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -340,17 +340,23 @@ type response struct {
 //
 //	conn.Send(msg, connection.SendTimeout(5 * time.Second))
 func (c *Connection) Send(message *iso8583.Message, options ...Option) (*iso8583.Message, error) {
-	// use send timeout value configured for the connection
-	opts := &Options{
-		SendTimeout: c.Opts.SendTimeout,
-	}
+	// use the SendTimeout from the connection options
+	sendTimeout := c.Opts.SendTimeout
 
-	// apply all options
-	for _, opt := range options {
-		opt(opts)
-	}
+	// Only if there are any options passed, apply them
+	if len(options) > 0 {
+		// use send timeout value configured for the connection
+		opts := &Options{
+			SendTimeout: sendTimeout,
+		}
 
-	sendTimeout := opts.SendTimeout
+		// apply all options
+		for _, opt := range options {
+			opt(opts)
+		}
+
+		sendTimeout = opts.SendTimeout
+	}
 
 	c.mutex.Lock()
 	if c.closing {

--- a/connection_test.go
+++ b/connection_test.go
@@ -449,6 +449,42 @@ func TestClient_Send(t *testing.T) {
 		require.Equal(t, connection.ErrSendTimeout, err)
 	})
 
+	t.Run("it does not return ErrSendTimeout when longer SendTimeout is set for Send", func(t *testing.T) {
+		c, err := connection.New(server.Addr, testSpec, readMessageLength, writeMessageLength, connection.SendTimeout(600*time.Millisecond))
+		require.NoError(t, err)
+
+		err = c.Connect()
+		require.NoError(t, err)
+		defer c.Close()
+
+		// regular network management message
+		message := iso8583.NewMessage(testSpec)
+		err = message.Marshal(baseFields{
+			MTI:  field.NewStringValue("0800"),
+			STAN: field.NewStringValue(getSTAN()),
+		})
+		require.NoError(t, err)
+
+		_, err = c.Send(message)
+		require.NoError(t, err)
+
+		// network management message to test timeout
+		message = iso8583.NewMessage(testSpec)
+		err = message.Marshal(baseFields{
+			MTI:          field.NewStringValue("0800"),
+			TestCaseCode: field.NewStringValue(TestCaseDelayedResponse),
+			STAN:         field.NewStringValue(getSTAN()),
+		})
+		require.NoError(t, err)
+
+		// connection is configured to use 600ms for SendTimeout, it means that
+		// all Send calls will not timeout, as test server is waiting for 500ms
+		// before sending response. So, to test SendTimeout for Send method
+		// we need to set it to smaller value than 500ms.
+		_, err = c.Send(message, connection.SendTimeout(100*time.Millisecond))
+		require.Equal(t, connection.ErrSendTimeout, err)
+	})
+
 	t.Run("it returns error when message does not have STAN", func(t *testing.T) {
 		c, err := connection.New(server.Addr, testSpec, readMessageLength, writeMessageLength, connection.SendTimeout(100*time.Millisecond))
 		require.NoError(t, err)

--- a/helper_test.go
+++ b/helper_test.go
@@ -149,7 +149,7 @@ func NewTestServerWithAddr(addr string) (*testServer, error) {
 
 			switch code {
 			case TestCaseDelayedResponse:
-				// testing value to "sleep" for a 3 seconds
+				// testing value to "sleep" for a 500ms
 				time.Sleep(500 * time.Millisecond)
 				c.Reply(message)
 			case TestCaseSameSTANRequest:


### PR DESCRIPTION
With this PR we make it possible to set custom `SendTimeout` value for the `Send` method call. Example:

```go
resp, err := conn.Send(message, connection.SendTimeout(100*time.Millisecond))
```

it's useful when you want to send Ping/Echo messages that may have their own round-trip times.