### PR TITLE
Cleanup duplicate calls to Connection.run()

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -138,7 +138,6 @@ func (c *Connection) Connect() error {
 	var err error
 
 	if c.conn != nil {
-		c.run()
 		return nil
 	}
 


### PR DESCRIPTION
This PR cleans up duplicate calls to `Connection.run()` - it will only be called when the underlying `conn` is first successfully created.

Currently when using a `Pool` with a `ConnectionFactoryFunc` that creates connections with `connection.NewFrom()` the created Connection's `run()` will be called twice, creating a duplicate set of go routines for the read and write loops: first by `NewFrom()` when the connection is created, and again in `Pool.Connect()`.
Any additional calls to `Connection.Connect()` will also result in additional calls to `Connection.run()`.
This can lead to extra calls to the configured `PingHandler` or `MessageReader`/`MessageWriter`.