### PR TITLE
close Pool when failed to Connect it

### DIFF
--- a/pool_options.go
+++ b/pool_options.go
@@ -11,7 +11,8 @@ type PoolOptions struct {
 	ReconnectWait time.Duration
 
 	// ErrorHandler is called in a goroutine with the errors that can't be
-	// returned to the caller
+	// returned to the caller. Don't block in this function as it will
+	// block the connection pool Close() method.
 	ErrorHandler func(err error)
 
 	// MinConnections is the number of connections required to be established when

--- a/pool_test.go
+++ b/pool_test.go
@@ -173,9 +173,9 @@ func TestPool(t *testing.T) {
 		require.NoError(t, err)
 
 		err = pool.Connect()
-		defer pool.Close()
-
+		require.Error(t, err)
 		require.Contains(t, err.Error(), "minimum 3 connections is required, established: 2")
+		require.Zero(t, len(pool.Connections()), "all connections should be closed")
 	})
 
 	t.Run("Connect() returns no error when established >= MinConnections and later re-establish failed connections", func(t *testing.T) {

--- a/pool_test.go
+++ b/pool_test.go
@@ -175,7 +175,7 @@ func TestPool(t *testing.T) {
 		err = pool.Connect()
 		defer pool.Close()
 
-		require.EqualError(t, err, "minimum 3 connections is required, established: 2")
+		require.Contains(t, err.Error(), "minimum 3 connections is required, established: 2")
 	})
 
 	t.Run("Connect() returns no error when established >= MinConnections and later re-establish failed connections", func(t *testing.T) {


### PR DESCRIPTION
This PR solves two issues:
1. If `pool.Connect` fails, it should call `pool.Close` to stop all running goroutines. `Connect` can fail when a minimum of 3 established connections are required, but only 2 were created. In this case we should close those 2 connections when we return error from `Connect`
2. Let's say we have the following code:

```go
		// factory creates the connection
		// ...

		pool, err := connection.NewPool(
			factory,
			[]string{addr},
			connection.PoolReconnectWait(5*time.Second),
			connection.PoolErrorHandler(func(err error) {
				fmt.Printf("pool error: %v\n", err)
			}),
		)

		err := pool.Connect()
                // if no minimal connections are established, currently you receive error here about it here
                // but without a specific connection error
                // specific connection error is passed to the `PoolErrorHandler`
```

Currently, we have an issue:
* when you call `pool.Connect()` and min number of connections can be established
* and your program terminates (e.g. test exits) before `PoolErrorHandler` asynchronous call is complete
* you may miss the connection error 🤷‍♂️

This PR applies the following changes to let us fix the issue:
* `Close` method will wait for all `PoolErrorHandler` goroutines to complete
* `pool.Connect()` will include all initial connection errors into returning the "min connections is required" error
* if `pool.Connect()` fails, then we close all existing connections and stop all goroutines