### PR TITLE
call ConnectionClosedHandlers when connection is closed by any side

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -259,12 +259,6 @@ func (c *Connection) handleConnectionError(err error) {
 
 	// close everything else we close normally
 	c.close()
-
-	if c.Opts.ConnectionClosedHandlers != nil && len(c.Opts.ConnectionClosedHandlers) > 0 {
-		for _, handler := range c.Opts.ConnectionClosedHandlers {
-			go handler(c)
-		}
-	}
 }
 
 func (c *Connection) close() error {
@@ -277,6 +271,12 @@ func (c *Connection) close() error {
 		err := c.conn.Close()
 		if err != nil {
 			return fmt.Errorf("closing connection: %w", err)
+		}
+	}
+
+	if c.Opts.ConnectionClosedHandlers != nil && len(c.Opts.ConnectionClosedHandlers) > 0 {
+		for _, handler := range c.Opts.ConnectionClosedHandlers {
+			go handler(c)
 		}
 	}
 

--- a/pool.go
+++ b/pool.go
@@ -161,6 +161,10 @@ func (p *Pool) handleClosedConnection(closedConn *Connection) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	if p.isClosed {
+		return
+	}
+
 	var connIndex = -1
 	for i, conn := range p.connections {
 		if conn == closedConn {
@@ -180,12 +184,6 @@ func (p *Pool) handleClosedConnection(closedConn *Connection) {
 	p.connections[connIndex] = p.connections[connsNum-1] // Copy last element to index connIndex.
 	p.connections[connsNum-1] = nil                      // Erase last element
 	p.connections = p.connections[:connsNum-1]           // Truncate slice.
-
-	// if pool was closed, don't start recreate goroutine
-	// should we return earlier and keep connection in the pool as it will be closed anyway?
-	if p.isClosed {
-		return
-	}
 
 	// initiate goroutine to reconnect to closedConn.Addr
 	p.wg.Add(1)


### PR DESCRIPTION
This PR addresses 3rd point in the #68 - which is:
* Invoke all `ConnectionClosedHandler` handlers regardless of how the connection was closed (by us, by the server, or due to a read/write error).