### PR TITLE
Message rejections

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -19,6 +19,19 @@ var (
 	ErrSendTimeout      = errors.New("message send timeout")
 )
 
+// RejectedMessageError is returned to the `Send` method caller when message is rejected.
+type RejectedMessageError struct {
+	Err error
+}
+
+func (e *RejectedMessageError) Error() string {
+	return fmt.Sprintf("message rejected: %s", e.Err.Error())
+}
+
+func (e *RejectedMessageError) Unwrap() error {
+	return e.Err
+}
+
 // MessageLengthReader reads message header from the r and returns message length
 type MessageLengthReader func(r io.Reader) (int, error)
 
@@ -729,8 +742,14 @@ func (c *Connection) Addr() string {
 	return c.addr
 }
 
-// RejectMessage returns error to the response err channel that corresponds to
-// the message ID (request ID)
+// RejectMessage returns RejectedMessageError to the response err channel that
+// corresponds to the ID of the rejectedMessage. This method is used to reject
+// messages that were sent to the network and response was received, but
+// response code indicates that message was rejected. In many cases, such
+// rejection happens outside of normal request-response flow, so it is not
+// possible to return response to the caller. In such cases,
+// RejectedMessageError is returned.  It's up to the implementation to decide
+// when to call RejectMessage and when to return RejectedMessageError.
 func (c *Connection) RejectMessage(rejectedMessage *iso8583.Message, rejectionError error) error {
 	reqID, err := c.Opts.RequestIDGenerator.GenerateRequestID(rejectedMessage)
 	if err != nil {
@@ -745,7 +764,7 @@ func (c *Connection) RejectMessage(rejectedMessage *iso8583.Message, rejectionEr
 		return fmt.Errorf("can't find response for ID: %s", reqID)
 	}
 
-	response.errCh <- fmt.Errorf("message rejected: %w", rejectionError)
+	response.errCh <- &RejectedMessageError{Err: rejectionError}
 
 	return nil
 }

--- a/connection.go
+++ b/connection.go
@@ -19,6 +19,18 @@ var (
 	ErrSendTimeout      = errors.New("message send timeout")
 )
 
+type RejectedMessageError struct {
+	Err error
+}
+
+func (e RejectedMessageError) Error() string {
+	return e.Err.Error()
+}
+
+func (e RejectedMessageError) Unwrap() error {
+	return e.Err
+}
+
 // MessageLengthReader reads message header from the r and returns message length
 type MessageLengthReader func(r io.Reader) (int, error)
 
@@ -727,4 +739,25 @@ func (c *Connection) Status() Status {
 // Addr returns the remote address of the connection
 func (c *Connection) Addr() string {
 	return c.addr
+}
+
+// RejectMessage returns error to the reply channel that corresponds to the
+// message ID (request ID)
+func (c *Connection) RejectMessage(rejectedMessage *iso8583.Message, reason string) error {
+	reqID, err := c.Opts.RequestIDGenerator.GenerateRequestID(rejectedMessage)
+	if err != nil {
+		return fmt.Errorf("creating request ID:  %w", err)
+	}
+
+	c.pendingRequestsMu.Lock()
+	response, found := c.respMap[reqID]
+	c.pendingRequestsMu.Unlock()
+
+	if !found {
+		return fmt.Errorf("can't find request for ID: %s", reqID)
+	}
+
+	response.errCh <- RejectedMessageError{Err: fmt.Errorf("message rejected: %s", reason)}
+
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/moov-io/iso8583-connection
 
-go 1.19
+go 1.21
 
 require (
-	github.com/moov-io/iso8583 v0.19.2
+	github.com/moov-io/iso8583 v0.19.3-0.20230922192946-2f27b3c8b7b0
 	github.com/stretchr/testify v1.8.4
 )
 
@@ -12,6 +12,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/yerden/go-util v1.1.4 // indirect
-	golang.org/x/text v0.11.0 // indirect
+	golang.org/x/text v0.12.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,11 +2,14 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/mediocregopher/radix.v2 v0.0.0-20181115013041-b67df6e626f9/go.mod h1:fLRUbhbSd5Px2yKUaGYYPltlyxi1guJz1vCmo1RQL50=
 github.com/moov-io/iso8583 v0.19.2 h1:xV5kY0t7UpN/d/polVdNt4Rj6ub4eZuTSTarSqC2NtQ=
 github.com/moov-io/iso8583 v0.19.2/go.mod h1:QPxDQTxKJPjECpK8vCsh7TpwvKyIrw3tXN/lrdATzCA=
+github.com/moov-io/iso8583 v0.19.3-0.20230922192946-2f27b3c8b7b0 h1:y0f/z9uGMIUjvEtnyE6WT91cYK1aZcsyeYh+lsPpZTQ=
+github.com/moov-io/iso8583 v0.19.3-0.20230922192946-2f27b3c8b7b0/go.mod h1:vvlp3liWXnH5pI9dl5PvrtpjS7ZxcdxyYWvd4FpI66A=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
@@ -14,9 +17,10 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/yerden/go-util v1.1.4 h1:jd8JyjLHzpEs1ZZQzDkfRgosDtXp/BtIAV1kpNjVTtw=
 github.com/yerden/go-util v1.1.4/go.mod h1:3HeLrvtkEeAv67ARostM9Yn0DcAVqgJ3uAiCuywEEXk=
 golang.org/x/sys v0.0.0-20190913121621-c3b328c6e5a7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.11.0 h1:LAntKIrcmeSKERyiOh0XMV39LXS8IE9UL2yP7+f5ij4=
-golang.org/x/text v0.11.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
+golang.org/x/text v0.12.0 h1:k+n5B8goJNdU7hSvEtMUz3d1Q6D/XW4COJSJR6fN0mc=
+golang.org/x/text v0.12.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/helper_test.go
+++ b/helper_test.go
@@ -190,6 +190,12 @@ func NewTestServerWithAddr(addr string) (*testServer, error) {
 	}
 
 	server := server.New(testSpec, readMessageLength, writeMessageLength, connection.InboundMessageHandler(testServerLogic))
+	server.SetOptions(
+		server.WithErrorHandler(func(err error) {
+			log.Printf("server error: %s", err.Error())
+		}),
+	)
+
 	// start on random port
 	err := server.Start(addr)
 	if err != nil {

--- a/helper_test.go
+++ b/helper_test.go
@@ -108,7 +108,8 @@ func (t *testServer) ReceivedPings() int {
 }
 
 const (
-	TestCaseReply           string = "000"
+	TestCaseReply string = "000"
+	// server waits for 500ms before reply
 	TestCaseDelayedResponse string = "001"
 	TestCasePingCounter     string = "002"
 	// for sending incoming message with same STAN as
@@ -150,7 +151,7 @@ func NewTestServerWithAddr(addr string) (*testServer, error) {
 			switch code {
 			case TestCaseDelayedResponse:
 				// testing value to "sleep" for a 500ms
-				time.Sleep(500 * time.Millisecond)
+				time.Sleep(5000 * time.Millisecond)
 				c.Reply(message)
 			case TestCaseSameSTANRequest:
 				// here we will send message to the client with

--- a/helper_test.go
+++ b/helper_test.go
@@ -189,22 +189,22 @@ func NewTestServerWithAddr(addr string) (*testServer, error) {
 		}
 	}
 
-	server := server.New(testSpec, readMessageLength, writeMessageLength, connection.InboundMessageHandler(testServerLogic))
-	server.SetOptions(
+	s := server.New(testSpec, readMessageLength, writeMessageLength, connection.InboundMessageHandler(testServerLogic))
+	s.SetOptions(
 		server.WithErrorHandler(func(err error) {
 			log.Printf("server error: %s", err.Error())
 		}),
 	)
 
 	// start on random port
-	err := server.Start(addr)
+	err := s.Start(addr)
 	if err != nil {
 		return nil, err
 	}
 
 	srv = &testServer{
-		Server: server,
-		Addr:   server.Addr,
+		Server: s,
+		Addr:   s.Addr,
 	}
 
 	return srv, nil

--- a/server/options.go
+++ b/server/options.go
@@ -10,3 +10,11 @@ func WithConnectionFactory(f ServerConnectionFactoryFunc) func(*Server) error {
 		return nil
 	}
 }
+
+func WithErrorHandler(f ErrorHandler) func(*Server) error {
+	return func(s *Server) error {
+		s.errorHandlers = append(s.errorHandlers, f)
+
+		return nil
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -15,9 +15,8 @@ import (
 type ConnectHandler func(conn net.Conn)
 
 // ErrorHandler is a function that will be called when error occurs during
-// connection handling. Note, that this function will be called in the same
-// goroutine as connection handling. It's up to the user to handle errors
-// and use goroutines if needed to avoid blocking the connection handling.
+// connection handling. Note, that this function may be called from different
+// goroutines, so it must be thread-safe
 type ErrorHandler func(err error)
 
 // ServerConnectionFactoryFunc is a function that creates new connection from

--- a/server/server.go
+++ b/server/server.go
@@ -64,7 +64,7 @@ type Server struct {
 	writeMessageLength connection.MessageLengthWriter
 
 	mu              sync.Mutex
-	ConnectHandlers []ConnectHandler
+	connectHandlers []ConnectHandler
 	isClosed        bool
 
 	// connectionFactory is a function that creates new connection
@@ -95,7 +95,7 @@ func (s *Server) SetOptions(opts ...func(*Server) error) error {
 func (s *Server) AddConnectionHandler(h ConnectHandler) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.ConnectHandlers = append(s.ConnectHandlers, h)
+	s.connectHandlers = append(s.connectHandlers, h)
 }
 
 func (s *Server) Start(addr string) error {
@@ -149,8 +149,8 @@ func (s *Server) Start(addr string) error {
 			go func() {
 				// notify all handlers about new connection
 				s.mu.Lock()
-				if s.ConnectHandlers != nil && len(s.ConnectHandlers) > 0 {
-					for _, h := range s.ConnectHandlers {
+				if s.connectHandlers != nil && len(s.connectHandlers) > 0 {
+					for _, h := range s.connectHandlers {
 						go h(conn)
 					}
 				}


### PR DESCRIPTION
This PR introduces the `RejectMessage` function to the connection. When invoked with a `rejectedMessage` and an `err`, it returns a `RejectedMessageError` which wraps `err`. This resulting error is then sent to the `response.errCh` matching the ID of the `rejectedMessage`.

## Motivation
Sometimes, messages sent to the network are rejected because of missing fields or invalid format. These rejections often occur outside the standard request-response cycle, making it tricky to relay the error back to the original caller.

To clarify, we've noticed two main ways servers reject ISO 8583 messages:
1. By sending a `0620` (administrative advice reject) ISO 8583 message containing the original message.
2. By sending a network header that flags the next message as rejected, like: `[network header with rejected flag][rejected message]`.

Consider this code:

```go
resp, err := iso8583Conn.Send(req)
```

If the `req` message is rejected, the `Send` call will timeout. This happens because the server can't process the request and doesn't send a response. Instead, it uses one of the two ways above. Currently, the `Connection` can't relay this rejection to the `Send` caller since there's no way to connect the rejected message with the original request.

Enter `RejectMessage`. If the `InboundMessageHandler` gets an incoming message (following way 1) and can extract the original rejected message, we can simply call `RejectMessage` with the original message and the desired error. This will instantly relay the error to the `Send` caller awaiting a response.

P.S. in addition, we added new option for `server.Server` to set error handler. This was done to get rid of inline calls of `fmt.Println`.
