### PR TITLE
add context for connect and close functions

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -2,6 +2,7 @@ package connection
 
 import (
 	"bufio"
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -107,6 +108,10 @@ func New(addr string, spec *iso8583.MessageSpec, mlReader MessageLengthReader, m
 		}
 	}
 
+	if err := opts.Validate(); err != nil {
+		return nil, fmt.Errorf("validating options: %w", err)
+	}
+
 	return &Connection{
 		addr:               addr,
 		Opts:               opts,
@@ -172,6 +177,49 @@ func (c *Connection) Connect() error {
 
 	if c.Opts.OnConnect != nil {
 		if err := c.Opts.OnConnect(c); err != nil {
+			// close connection if OnConnect failed
+			// but ignore the potential error from Close()
+			// as it's a rare case
+			_ = c.Close()
+
+			return fmt.Errorf("on connect callback %s: %w", c.addr, err)
+		}
+	}
+
+	if c.Opts.ConnectionEstablishedHandler != nil {
+		go c.Opts.ConnectionEstablishedHandler(c)
+	}
+
+	return nil
+}
+
+// ConnectCtx establishes the connection to the server using configured Addr
+func (c *Connection) ConnectCtx(ctx context.Context) error {
+	var conn net.Conn
+	var err error
+
+	if c.conn != nil {
+		return nil
+	}
+
+	d := &net.Dialer{Timeout: c.Opts.ConnectTimeout}
+
+	if c.Opts.TLSConfig != nil {
+		conn, err = tls.DialWithDialer(d, "tcp", c.addr, c.Opts.TLSConfig)
+	} else {
+		conn, err = d.Dial("tcp", c.addr)
+	}
+
+	if err != nil {
+		return fmt.Errorf("connecting to server %s: %w", c.addr, err)
+	}
+
+	c.conn = conn
+
+	c.run()
+
+	if c.Opts.OnConnectCtx != nil {
+		if err := c.Opts.OnConnectCtx(ctx, c); err != nil {
 			// close connection if OnConnect failed
 			// but ignore the potential error from Close()
 			// as it's a rare case
@@ -261,7 +309,6 @@ func (c *Connection) handleConnectionError(err error) {
 			case <-done:
 				return
 			}
-
 		}
 	}()
 
@@ -301,6 +348,27 @@ func (c *Connection) close() error {
 func (c *Connection) Close() error {
 	if c.Opts.OnClose != nil {
 		if err := c.Opts.OnClose(c); err != nil {
+			return fmt.Errorf("on close callback: %w", err)
+		}
+	}
+
+	c.mutex.Lock()
+	// if we are closing already, just return
+	if c.closing {
+		c.mutex.Unlock()
+		return nil
+	}
+	c.closing = true
+	c.mutex.Unlock()
+
+	return c.close()
+}
+
+// CloseCtx waits for pending requests to complete and then closes network
+// connection with ISO 8583 server
+func (c *Connection) CloseCtx(ctx context.Context) error {
+	if c.Opts.OnCloseCtx != nil {
+		if err := c.Opts.OnCloseCtx(ctx, c); err != nil {
 			return fmt.Errorf("on close callback: %w", err)
 		}
 	}

--- a/connection_test.go
+++ b/connection_test.go
@@ -1160,36 +1160,6 @@ func TestClient_Options(t *testing.T) {
 
 		require.Equal(t, 1, callsCounter)
 	})
-
-	t.Run("Cannot configure OnConnect and OnConnectCtx", func(t *testing.T) {
-		c, err := connection.New(
-			"localhost:0",
-			testSpec,
-			readMessageLength,
-			writeMessageLength,
-			connection.SendTimeout(500*time.Millisecond),
-			connection.OnConnect(func(c *connection.Connection) error { return nil }),
-			connection.OnConnectCtx(func(ctx context.Context, c *connection.Connection) error { return nil }),
-		)
-
-		require.Error(t, err)
-		require.Nil(t, c)
-	})
-
-	t.Run("Cannot configure OnClose and OnCloseCtx", func(t *testing.T) {
-		c, err := connection.New(
-			"localhost:0",
-			testSpec,
-			readMessageLength,
-			writeMessageLength,
-			connection.SendTimeout(500*time.Millisecond),
-			connection.OnClose(func(c *connection.Connection) error { return nil }),
-			connection.OnCloseCtx(func(ctx context.Context, c *connection.Connection) error { return nil }),
-		)
-
-		require.Error(t, err)
-		require.Nil(t, c)
-	})
 }
 
 func TestClientWithMessageReaderAndWriter(t *testing.T) {

--- a/connection_test.go
+++ b/connection_test.go
@@ -188,9 +188,6 @@ func TestClient_Connect(t *testing.T) {
 		c, err := connection.New(server.Addr, testSpec, readMessageLength, writeMessageLength, connection.OnClose(onClose))
 		require.NoError(t, err)
 
-		// err = c.Connect()
-		// require.NoError(t, err)
-
 		err = c.Close()
 		require.NoError(t, err)
 
@@ -214,9 +211,6 @@ func TestClient_Connect(t *testing.T) {
 
 		c, err := connection.New(server.Addr, testSpec, readMessageLength, writeMessageLength, connection.OnCloseCtx(onCloseCtx))
 		require.NoError(t, err)
-
-		// err = c.Connect()
-		// require.NoError(t, err)
 
 		err = c.CloseCtx(context.Background())
 		require.NoError(t, err)

--- a/connection_test.go
+++ b/connection_test.go
@@ -2,6 +2,7 @@ package connection_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -27,8 +28,10 @@ type baseFields struct {
 	STAN         *field.String `index:"11"`
 }
 
-var stan int
-var stanMu sync.Mutex
+var (
+	stan   int
+	stanMu sync.Mutex
+)
 
 func getSTAN() string {
 	stanMu.Lock()
@@ -145,6 +148,31 @@ func TestClient_Connect(t *testing.T) {
 		}, 100*time.Millisecond, 20*time.Millisecond, "onConnect should be called")
 	})
 
+	t.Run("OnConnectCtx is called", func(t *testing.T) {
+		server, err := NewTestServer()
+		require.NoError(t, err)
+		defer server.Close()
+
+		var onConnectCalled int32
+		onConnectCtx := func(ctx context.Context, c *connection.Connection) error {
+			// increase the counter
+			atomic.AddInt32(&onConnectCalled, 1)
+			return nil
+		}
+
+		c, err := connection.New(server.Addr, testSpec, readMessageLength, writeMessageLength, connection.OnConnectCtx(onConnectCtx))
+		require.NoError(t, err)
+
+		err = c.ConnectCtx(context.Background())
+		require.NoError(t, err)
+		defer c.Close()
+
+		// eventually the onConnectCounter should be 1
+		require.Eventually(t, func() bool {
+			return atomic.LoadInt32(&onConnectCalled) == 1
+		}, 100*time.Millisecond, 20*time.Millisecond, "onConnect should be called")
+	})
+
 	t.Run("OnClose is called", func(t *testing.T) {
 		server, err := NewTestServer()
 		require.NoError(t, err)
@@ -164,6 +192,33 @@ func TestClient_Connect(t *testing.T) {
 		// require.NoError(t, err)
 
 		err = c.Close()
+		require.NoError(t, err)
+
+		// eventually the onClosedCalled should be 1
+		require.Eventually(t, func() bool {
+			return atomic.LoadInt32(&onClosedCalled) == 1
+		}, 100*time.Millisecond, 20*time.Millisecond, "onClose should be called")
+	})
+
+	t.Run("OnCloseCtx is called", func(t *testing.T) {
+		server, err := NewTestServer()
+		require.NoError(t, err)
+		defer server.Close()
+
+		var onClosedCalled int32
+		onCloseCtx := func(ctx context.Context, c *connection.Connection) error {
+			// increase the counter
+			atomic.AddInt32(&onClosedCalled, 1)
+			return nil
+		}
+
+		c, err := connection.New(server.Addr, testSpec, readMessageLength, writeMessageLength, connection.OnCloseCtx(onCloseCtx))
+		require.NoError(t, err)
+
+		// err = c.Connect()
+		// require.NoError(t, err)
+
+		err = c.CloseCtx(context.Background())
 		require.NoError(t, err)
 
 		// eventually the onClosedCalled should be 1
@@ -682,7 +737,6 @@ func TestClient_Send(t *testing.T) {
 
 		// and that response for the first message was received second
 		require.Equal(t, receivedSTANs[1], stan1)
-
 	})
 
 	t.Run("automatically sends ping messages after ping interval", func(t *testing.T) {
@@ -985,7 +1039,6 @@ func TestClient_Send(t *testing.T) {
 			return server.ReceivedPings() > 0
 		}, 200*time.Millisecond, 50*time.Millisecond, "no ping messages were sent after read timeout")
 	})
-
 }
 
 func TestClient_Options(t *testing.T) {
@@ -1019,7 +1072,6 @@ func TestClient_Options(t *testing.T) {
 		require.Eventually(t, func() bool {
 			return atomic.LoadInt32(&callsCounter) > 0
 		}, 500*time.Millisecond, 50*time.Millisecond, "error handler was never called")
-
 	})
 
 	t.Run("ClosedHandler is called when connection is closed", func(t *testing.T) {
@@ -1107,6 +1159,36 @@ func TestClient_Options(t *testing.T) {
 		}, 200*time.Millisecond, 10*time.Millisecond)
 
 		require.Equal(t, 1, callsCounter)
+	})
+
+	t.Run("Cannot configure OnConnect and OnConnectCtx", func(t *testing.T) {
+		c, err := connection.New(
+			"localhost:0",
+			testSpec,
+			readMessageLength,
+			writeMessageLength,
+			connection.SendTimeout(500*time.Millisecond),
+			connection.OnConnect(func(c *connection.Connection) error { return nil }),
+			connection.OnConnectCtx(func(ctx context.Context, c *connection.Connection) error { return nil }),
+		)
+
+		require.Error(t, err)
+		require.Nil(t, c)
+	})
+
+	t.Run("Cannot configure OnClose and OnCloseCtx", func(t *testing.T) {
+		c, err := connection.New(
+			"localhost:0",
+			testSpec,
+			readMessageLength,
+			writeMessageLength,
+			connection.SendTimeout(500*time.Millisecond),
+			connection.OnClose(func(c *connection.Connection) error { return nil }),
+			connection.OnCloseCtx(func(ctx context.Context, c *connection.Connection) error { return nil }),
+		)
+
+		require.Error(t, err)
+		require.Nil(t, c)
 	})
 }
 
@@ -1319,9 +1401,11 @@ func (m *TrackingRWCloser) Write(p []byte) (n int, err error) {
 
 	return 0, nil
 }
+
 func (m *TrackingRWCloser) Read(p []byte) (n int, err error) {
 	return 0, nil
 }
+
 func (m *TrackingRWCloser) Close() error {
 	return nil
 }

--- a/options.go
+++ b/options.go
@@ -111,16 +111,6 @@ func GetDefaultOptions() Options {
 	}
 }
 
-func (o *Options) Validate() error {
-	if o.OnConnect != nil && o.OnConnectCtx != nil {
-		return fmt.Errorf("OnConnect and OnConnectCtx are mutually exclusive")
-	}
-	if o.OnClose != nil && o.OnCloseCtx != nil {
-		return fmt.Errorf("OnClose and OnCloseCtx are mutually exclusive")
-	}
-	return nil
-}
-
 // IdleTime sets an IdleTime option
 func IdleTime(d time.Duration) Option {
 	return func(o *Options) error {

--- a/options.go
+++ b/options.go
@@ -61,15 +61,14 @@ type Options struct {
 	// returned to the caller
 	ErrorHandler func(err error)
 
-	// Only define a single OnConnect and OnClose functions
-	// the config will error out if both are set
-
+	// If both OnConnect and OnConnectCtx are set, OnConnectCtx will be used
 	// OnConnect is called synchronously when a connection is established
 	OnConnect func(c *Connection) error
 
 	// OnConnectCtx is called synchronously when a connection is established
 	OnConnectCtx func(ctx context.Context, c *Connection) error
 
+	// If both OnClose and OnCloseCtx are set, OnCloseCtx will be used
 	// OnClose is called synchronously before a connection is closed
 	OnClose func(c *Connection) error
 

--- a/pool.go
+++ b/pool.go
@@ -1,6 +1,7 @@
 package connection
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -62,6 +63,11 @@ func (p *Pool) handleError(err error) {
 
 // Connect creates poll of connections by calling Factory method and connect them all
 func (p *Pool) Connect() error {
+	return p.ConnectCtx(context.Background())
+}
+
+// Connect creates poll of connections by calling Factory method and connect them all
+func (p *Pool) ConnectCtx(ctx context.Context) error {
 	// We need to close pool (with all potentially running goroutines) if
 	// connection creation fails. Example of such situation is when we
 	// successfully created 2 connections, but 3rd failed and minimum
@@ -72,7 +78,7 @@ func (p *Pool) Connect() error {
 	var connectErr error
 	defer func() {
 		if connectErr != nil {
-			p.Close()
+			p.CloseCtx(ctx)
 		}
 	}()
 
@@ -95,7 +101,7 @@ func (p *Pool) Connect() error {
 		// set own handler when connection is closed
 		conn.SetOptions(ConnectionClosedHandler(p.handleClosedConnection))
 
-		err = conn.Connect()
+		err = conn.ConnectCtx(ctx)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("connecting to %s: %w", addr, err))
 			p.handleError(fmt.Errorf("failed to connect to %s: %w", conn.addr, err))
@@ -234,6 +240,11 @@ func (p *Pool) recreateConnection(closedConn *Connection) {
 
 // Close closes all connections in the pool
 func (p *Pool) Close() error {
+	return p.CloseCtx(context.Background())
+}
+
+// CloseCtx closes all connections in the pool
+func (p *Pool) CloseCtx(ctx context.Context) error {
 	p.mu.Lock()
 	if p.isClosed {
 		p.mu.Unlock()

--- a/pool.go
+++ b/pool.go
@@ -165,7 +165,7 @@ func (p *Pool) handleClosedConnection(closedConn *Connection) {
 		return
 	}
 
-	var connIndex = -1
+	connIndex := -1
 	for i, conn := range p.connections {
 		if conn == closedConn {
 			connIndex = i
@@ -264,7 +264,6 @@ func (p *Pool) Close() error {
 				p.handleError(fmt.Errorf("closing connection on pool close: %w", err))
 			}
 		}(conn)
-
 	}
 	wg.Wait()
 

--- a/pool.go
+++ b/pool.go
@@ -270,7 +270,7 @@ func (p *Pool) CloseCtx(ctx context.Context) error {
 	for _, conn := range p.connections {
 		go func(conn *Connection) {
 			defer wg.Done()
-			err := conn.Close()
+			err := conn.CloseCtx(ctx)
 			if err != nil {
 				p.handleError(fmt.Errorf("closing connection on pool close: %w", err))
 			}


### PR DESCRIPTION
This adds functions:

- `ConnectCtx`
- `CloseCtx`
- `OnConnectCtx`
- `OnCloseCtx`

that mimic the same functions without `Ctx` but allow passing in a context object. This can be useful for adding telemetry, etc.

I am not a huge fan of the names of things, but since I wanted to maintain backwards compatibility with the library I couldn't really figure out a better way to do this.