### PR TITLE
Report err from OnClose and Close Connection Regardless of the Error

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -326,7 +326,7 @@ func (c *Connection) CloseCtx(ctx context.Context) error {
 
 	if onClose != nil {
 		if err := onClose(ctx, c); err != nil {
-			return fmt.Errorf("on close callback: %w", err)
+			c.handleError(fmt.Errorf("on close callback: %w", err))
 		}
 	}
 


### PR DESCRIPTION
Currently, when we return `err` from the `OnClose` or `OnCloseCtx` handler, we do not close the connection. Leaking connections is a big problem. With this PR, we pass `err` into `ErrorHandler` so it can be handled, logged, etc., and then proceed with the connection close.