### PR TITLE
Conn pool improvements

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -201,11 +201,11 @@ func (c *Connection) ConnectCtx(ctx context.Context) error {
 
 	if onConnect != nil {
 		if err := onConnect(ctx, c); err != nil {
-			// close connection if OnConnect failed
-			// but ignore the potential error from Close()
-			// as it's a rare case
+			// we can do the hard close here by calling TriggerFailure
+			// If connection is not Online, pool will not return it and
+			// no one will be able to use it. The rest of the messages
+			// like echo, ping should be safe to terminate
 			c.TriggerFailure(fmt.Errorf("on connect callback %s: %w", c.addr, err))
-			// _ = c.CloseCtx(ctx)
 
 			return fmt.Errorf("on connect callback %s: %w", c.addr, err)
 		}

--- a/connection.go
+++ b/connection.go
@@ -102,7 +102,13 @@ type Connection struct {
 var _ io.Writer = (*Connection)(nil)
 
 // New creates and configures Connection. To establish network connection, call `Connect()`.
-func New(addr string, spec *iso8583.MessageSpec, mlReader MessageLengthReader, mlWriter MessageLengthWriter, options ...Option) (*Connection, error) {
+func New(
+	addr string,
+	spec *iso8583.MessageSpec,
+	mlReader MessageLengthReader,
+	mlWriter MessageLengthWriter,
+	options ...Option,
+) (*Connection, error) {
 	opts := GetDefaultOptions()
 	for _, opt := range options {
 		if err := opt(&opts); err != nil {
@@ -127,7 +133,13 @@ func New(addr string, spec *iso8583.MessageSpec, mlReader MessageLengthReader, m
 // NewFrom accepts conn (net.Conn, or any io.ReadWriteCloser) which will be
 // used as a transport for the returned Connection. Returned Connection is
 // ready to be used for message sending and receiving
-func NewFrom(conn io.ReadWriteCloser, spec *iso8583.MessageSpec, mlReader MessageLengthReader, mlWriter MessageLengthWriter, options ...Option) (*Connection, error) {
+func NewFrom(
+	conn io.ReadWriteCloser,
+	spec *iso8583.MessageSpec,
+	mlReader MessageLengthReader,
+	mlWriter MessageLengthWriter,
+	options ...Option,
+) (*Connection, error) {
 	c, err := New("", spec, mlReader, mlWriter, options...)
 	if err != nil {
 		return nil, fmt.Errorf("creating client: %w", err)

--- a/connection.go
+++ b/connection.go
@@ -325,7 +325,7 @@ func (c *Connection) close() error {
 }
 
 func (c *Connection) closeConn() {
-	t := time.AfterFunc(250*time.Millisecond, c.forceCloseConn)
+	t := time.AfterFunc(500*time.Millisecond, c.forceCloseConn)
 	defer t.Stop()
 	c.conn.Close()
 }

--- a/options.go
+++ b/options.go
@@ -171,12 +171,17 @@ func PingHandler(handler func(c *Connection)) Option {
 	}
 }
 
-// ConnectionClosedHandler sets a ConnectionClosedHandler option
-func ConnectionClosedHandler(handler func(c *Connection)) Option {
+// WithConnectionClosedHandler sets a ConnectionClosedHandler option.
+func WithConnectionClosedHandler(handler func(c *Connection)) Option {
 	return func(o *Options) error {
 		o.ConnectionClosedHandlers = append(o.ConnectionClosedHandlers, handler)
 		return nil
 	}
+}
+
+// ConnectionClosedHandler sets a ConnectionClosedHandler option
+func ConnectionClosedHandler(handler func(c *Connection)) Option {
+	return WithConnectionClosedHandler(handler)
 }
 
 // ConnectionFailedHandler is a function that will be called when a connection fails due to network issues

--- a/options.go
+++ b/options.go
@@ -31,12 +31,6 @@ type Options struct {
 	// The default is 60 seconds.
 	ReadTimeout time.Duration
 
-	// CloseTimeout is the maximum time to wait for a graceful
-	// connection of the underlying connection. If the connection
-	// is not closed within this time, it will be ignored and
-	// all handlers will be called.
-	CloseTimeout time.Duration
-
 	// PingHandler is called when no message was sent during idle time
 	// it should be safe for concurrent use
 	PingHandler func(c *Connection)
@@ -123,7 +117,6 @@ func GetDefaultOptions() Options {
 		SendTimeout:        30 * time.Second,
 		IdleTime:           5 * time.Second,
 		ReadTimeout:        60 * time.Second,
-		CloseTimeout:       5 * time.Second,
 		PingHandler:        nil,
 		TLSConfig:          nil,
 		RequestIDGenerator: &defaultRequestIDGenerator{},
@@ -334,14 +327,6 @@ func SetMessageReader(r MessageReader) Option {
 func SetMessageWriter(w MessageWriter) Option {
 	return func(o *Options) error {
 		o.MessageWriter = w
-		return nil
-	}
-}
-
-// WithCloseTimeout sets a CloseTimeout option
-func WithCloseTimeout(d time.Duration) Option {
-	return func(o *Options) error {
-		o.CloseTimeout = d
 		return nil
 	}
 }

--- a/pool.go
+++ b/pool.go
@@ -180,10 +180,10 @@ func (p *Pool) handleClosedConnection(closedConn *Connection, _ error) {
 		}
 	}
 
-	// somehow we didn't find closed connection in the pool
-	// most probably we failed to establish it and it was never added to the pool
+	// do nothing if connection wasn't found in the pool
+	// connection either wasn't added to the pool or was already removed from the pool
+	// and connection is in the process of being recreated
 	if connIndex < 0 {
-		p.handleError(errors.New("connection was not found in the pool"))
 		return
 	}
 

--- a/pool.go
+++ b/pool.go
@@ -100,7 +100,7 @@ func (p *Pool) ConnectCtx(ctx context.Context) error {
 		}
 
 		// set own handler when connection is closed
-		conn.SetOptions(WithConnectionFailedHandler(p.handleClosedConnection))
+		conn.SetOptions(WithConnectionClosedHandler(p.handleClosedConnection))
 
 		err = conn.ConnectCtx(ctx)
 		if err != nil {
@@ -164,7 +164,7 @@ func (p *Pool) Get() (*Connection, error) {
 
 // when connection is closed, remove it from the pool of connections and start
 // goroutine to create new connection for the same address
-func (p *Pool) handleClosedConnection(closedConn *Connection, _ error) {
+func (p *Pool) handleClosedConnection(closedConn *Connection) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -227,7 +227,7 @@ func (p *Pool) recreateConnection(closedConn *Connection) {
 
 		// When connection is closed, remove it from the pool of connections and start
 		// recreate goroutine to create new connection for the same address
-		conn.SetOptions(WithConnectionFailedHandler(p.handleClosedConnection))
+		conn.SetOptions(WithConnectionClosedHandler(p.handleClosedConnection))
 
 		// if we successfully reconnected, add connection to the pool and return
 		if err = conn.Connect(); err == nil {

--- a/pool_test.go
+++ b/pool_test.go
@@ -44,8 +44,19 @@ func TestPool(t *testing.T) {
 		}
 	}()
 
+	// vars to control factory behavior
+	var (
+		shouldFactoryFail atomic.Bool
+		factoryCalled     atomic.Int32
+	)
+
 	// And a factory method that will build connection for the pool
 	factory := func(addr string) (*connection.Connection, error) {
+		factoryCalled.Add(1)
+
+		if shouldFactoryFail.Load() {
+			return nil, fmt.Errorf("factory error")
+		}
 		// all our addresses have same configs, but if you need to use
 		// different TLS config, you can define config out of this
 		// function like:
@@ -148,6 +159,45 @@ func TestPool(t *testing.T) {
 		require.Eventually(t, func() bool {
 			return len(pool.Connections()) == connectionsCntBeforeServerShutdown
 		}, 2000*time.Millisecond, 50*time.Millisecond, "expect to have one less connection")
+	})
+
+	t.Run("connection factory returning error should not break the reconnect loop", func(t *testing.T) {
+		connectionsCntBeforeServerShutdown := len(pool.Connections())
+
+		// when we shutdown one of the servers
+		servers[0].Close()
+
+		// then we have one less connection
+		require.Eventually(t, func() bool {
+			return len(pool.Connections()) == connectionsCntBeforeServerShutdown-1
+		}, 500*time.Millisecond, 50*time.Millisecond, "expect to have one less connection")
+
+		// let factory return error
+		shouldFactoryFail.Store(true)
+
+		// reset factoryCalled counter
+		factoryCalled.Store(0)
+
+		// wait for the reconnect loop to call factory at least once
+		require.Eventually(t, func() bool {
+			return factoryCalled.Load() > 0
+		}, 1000*time.Millisecond, 50*time.Millisecond, "expect factory to be called at least once")
+
+		// stop returning error for factory
+		shouldFactoryFail.Store(false)
+
+		// when we start server again
+		server, err := NewTestServerWithAddr(servers[0].Addr)
+		require.NoError(t, err)
+
+		// so we will not forget to close server on exit
+		servers[0] = server
+
+		// then we have one more connection (the same as it was before
+		// we shut down the server)
+		require.Eventually(t, func() bool {
+			return len(pool.Connections()) == connectionsCntBeforeServerShutdown
+		}, 2000*time.Millisecond, 50*time.Millisecond, "expect to have the same number of connections after restarting the server")
 	})
 
 	t.Run("when MaxReconnectWait is set reconnect wait time will exponentially increase", func(t *testing.T) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -94,6 +94,8 @@ func TestServer_WithConnectionFactory(t *testing.T) {
 		err = conn.Connect()
 		require.NoError(t, err)
 
+		time.Sleep(50 * time.Millisecond) // give some time for the connection to be established
+
 		err = conn.Close()
 		require.NoError(t, err)
 


### PR DESCRIPTION
This PR introduces several key improvements to connection handling and pool management:

  Connection Lifecycle Management:
  - Added force close mechanism for hanging TLS connections using TCP RST to prevent indefinite hangs 
  - Fixed race conditions in connection closing by moving closing flag checks earlier in the Send method

  Pool Reliability:
  - Fixed reconnection logic to continue retry loops even when factory fails to build connections
  - Added new `ConnectionFailedHandler` type for better error handling during network failures and to help distinguish closed by us from closed by them / due to error.
  - Improved connection filtering to exclude non-alive connections (the one we are closing) from pool operations

These changes improve connection pool stability under network failures and provide better mechanisms for handling connection errors.