### PR TITLE
Add zizmor GitHub Actions security analysis

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,16 @@
+# Use https://app.stepsecurity.io/ to improve workflow security
+name: zizmor
+
+on:
+  push:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    uses: moov-io/.github/.github/workflows/zizmor.yml@768836368a4ebdf0959c6497d41433e7193103cc


### PR DESCRIPTION
## Summary
- Adds a thin caller that runs [zizmor](https://docs.zizmor.sh) on every push and pull request.
- The job lives in [`moov-io/.github`](https://github.com/moov-io/.github/blob/master/.github/workflows/zizmor.yml) so the action version is shared across the org.

Findings are uploaded to **Security → Code scanning** and do not fail CI. Existing workflow issues can be triaged there.

## Test plan
- [x] Confirm the `zizmor` workflow runs on this PR
- [x] Confirm results appear under Security → Code scanning